### PR TITLE
Add an autogenerated API client

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ To perform a production build with minified outputs:
 yarn build
 ```
 
+### Updating the API Client
+
+This will fetch the latest OpenAPI schema for the Sindri API and autogenerate an updated API client in [`src/lib/api/`](src/lib/api/).
+
+```bash
+yarn generate-api
+```
+
 ### Linting
 
 To lint the project with Eslint and Prettier:

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
   "scripts": {
     "build": "NODE_ENV=production tsup",
     "build:watch": "NODE_ENV=development tsup --watch",
+    "generate-api": "rm -rf src/lib/api/ && openapi --input https://forge.sindri.app/api/openapi.json --output src/lib/api/ && prettier --write src/lib/api/**/*",
+    "generate-api:dev": "rm -rf src/lib/api/ && openapi --input http://localhost/api/openapi.json --output src/lib/api/ && prettier --write src/lib/api/**/*",
     "lint": "eslint '**/*.{js,ts}'",
     "format": "prettier --write '**/*.{js,json,md,ts}'",
     "type-check": "tsc --noEmit"
@@ -45,6 +47,7 @@
     "eslint": "^8.53.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.1",
+    "openapi-typescript-codegen": "^0.25.0",
     "prettier": "^3.1.0",
     "tsup": "^7.3.0",
     "typescript": "^5.2.2"

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "scripts": {
     "build": "NODE_ENV=production tsup",
     "build:watch": "NODE_ENV=development tsup --watch",
-    "generate-api": "rm -rf src/lib/api/ && openapi --input https://forge.sindri.app/api/openapi.json --output src/lib/api/ && prettier --write src/lib/api/**/*",
-    "generate-api:dev": "rm -rf src/lib/api/ && openapi --input http://localhost/api/openapi.json --output src/lib/api/ && prettier --write src/lib/api/**/*",
+    "generate-api": "rm -rf src/lib/api/ && openapi --client axios --input https://forge.sindri.app/api/openapi.json --output src/lib/api/ && prettier --write src/lib/api/**/*",
+    "generate-api:dev": "rm -rf src/lib/api/ && openapi --client axios --input http://localhost/api/openapi.json --output src/lib/api/ && prettier --write src/lib/api/**/*",
     "lint": "eslint '**/*.{js,ts}'",
     "format": "prettier --write '**/*.{js,json,md,ts}'",
     "type-check": "tsc --noEmit"
@@ -38,7 +38,10 @@
     "url": "https://github.com/Sindri-Labs/sindri-js/issues"
   },
   "homepage": "https://github.com/Sindri-Labs/sindri-js#readme",
-  "dependencies": {},
+  "dependencies": {
+    "axios": "^1.6.2",
+    "form-data": "^4.0.0"
+  },
   "devDependencies": {
     "@tsconfig/node18": "^18.2.2",
     "@types/node": "^20.9.1",

--- a/src/lib/api/core/ApiError.ts
+++ b/src/lib/api/core/ApiError.ts
@@ -1,0 +1,29 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ApiRequestOptions } from "./ApiRequestOptions";
+import type { ApiResult } from "./ApiResult";
+
+export class ApiError extends Error {
+  public readonly url: string;
+  public readonly status: number;
+  public readonly statusText: string;
+  public readonly body: any;
+  public readonly request: ApiRequestOptions;
+
+  constructor(
+    request: ApiRequestOptions,
+    response: ApiResult,
+    message: string,
+  ) {
+    super(message);
+
+    this.name = "ApiError";
+    this.url = response.url;
+    this.status = response.status;
+    this.statusText = response.statusText;
+    this.body = response.body;
+    this.request = request;
+  }
+}

--- a/src/lib/api/core/ApiRequestOptions.ts
+++ b/src/lib/api/core/ApiRequestOptions.ts
@@ -1,0 +1,24 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ApiRequestOptions = {
+  readonly method:
+    | "GET"
+    | "PUT"
+    | "POST"
+    | "DELETE"
+    | "OPTIONS"
+    | "HEAD"
+    | "PATCH";
+  readonly url: string;
+  readonly path?: Record<string, any>;
+  readonly cookies?: Record<string, any>;
+  readonly headers?: Record<string, any>;
+  readonly query?: Record<string, any>;
+  readonly formData?: Record<string, any>;
+  readonly body?: any;
+  readonly mediaType?: string;
+  readonly responseHeader?: string;
+  readonly errors?: Record<number, string>;
+};

--- a/src/lib/api/core/ApiResult.ts
+++ b/src/lib/api/core/ApiResult.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export type ApiResult = {
+  readonly url: string;
+  readonly ok: boolean;
+  readonly status: number;
+  readonly statusText: string;
+  readonly body: any;
+};

--- a/src/lib/api/core/CancelablePromise.ts
+++ b/src/lib/api/core/CancelablePromise.ts
@@ -1,0 +1,130 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export class CancelError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CancelError";
+  }
+
+  public get isCancelled(): boolean {
+    return true;
+  }
+}
+
+export interface OnCancel {
+  readonly isResolved: boolean;
+  readonly isRejected: boolean;
+  readonly isCancelled: boolean;
+
+  (cancelHandler: () => void): void;
+}
+
+export class CancelablePromise<T> implements Promise<T> {
+  #isResolved: boolean;
+  #isRejected: boolean;
+  #isCancelled: boolean;
+  readonly #cancelHandlers: (() => void)[];
+  readonly #promise: Promise<T>;
+  #resolve?: (value: T | PromiseLike<T>) => void;
+  #reject?: (reason?: any) => void;
+
+  constructor(
+    executor: (
+      resolve: (value: T | PromiseLike<T>) => void,
+      reject: (reason?: any) => void,
+      onCancel: OnCancel,
+    ) => void,
+  ) {
+    this.#isResolved = false;
+    this.#isRejected = false;
+    this.#isCancelled = false;
+    this.#cancelHandlers = [];
+    this.#promise = new Promise<T>((resolve, reject) => {
+      this.#resolve = resolve;
+      this.#reject = reject;
+
+      const onResolve = (value: T | PromiseLike<T>): void => {
+        if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+          return;
+        }
+        this.#isResolved = true;
+        this.#resolve?.(value);
+      };
+
+      const onReject = (reason?: any): void => {
+        if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+          return;
+        }
+        this.#isRejected = true;
+        this.#reject?.(reason);
+      };
+
+      const onCancel = (cancelHandler: () => void): void => {
+        if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+          return;
+        }
+        this.#cancelHandlers.push(cancelHandler);
+      };
+
+      Object.defineProperty(onCancel, "isResolved", {
+        get: (): boolean => this.#isResolved,
+      });
+
+      Object.defineProperty(onCancel, "isRejected", {
+        get: (): boolean => this.#isRejected,
+      });
+
+      Object.defineProperty(onCancel, "isCancelled", {
+        get: (): boolean => this.#isCancelled,
+      });
+
+      return executor(onResolve, onReject, onCancel as OnCancel);
+    });
+  }
+
+  get [Symbol.toStringTag]() {
+    return "Cancellable Promise";
+  }
+
+  public then<TResult1 = T, TResult2 = never>(
+    onFulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | null,
+    onRejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null,
+  ): Promise<TResult1 | TResult2> {
+    return this.#promise.then(onFulfilled, onRejected);
+  }
+
+  public catch<TResult = never>(
+    onRejected?: ((reason: any) => TResult | PromiseLike<TResult>) | null,
+  ): Promise<T | TResult> {
+    return this.#promise.catch(onRejected);
+  }
+
+  public finally(onFinally?: (() => void) | null): Promise<T> {
+    return this.#promise.finally(onFinally);
+  }
+
+  public cancel(): void {
+    if (this.#isResolved || this.#isRejected || this.#isCancelled) {
+      return;
+    }
+    this.#isCancelled = true;
+    if (this.#cancelHandlers.length) {
+      try {
+        for (const cancelHandler of this.#cancelHandlers) {
+          cancelHandler();
+        }
+      } catch (error) {
+        console.warn("Cancellation threw an error", error);
+        return;
+      }
+    }
+    this.#cancelHandlers.length = 0;
+    this.#reject?.(new CancelError("Request aborted"));
+  }
+
+  public get isCancelled(): boolean {
+    return this.#isCancelled;
+  }
+}

--- a/src/lib/api/core/OpenAPI.ts
+++ b/src/lib/api/core/OpenAPI.ts
@@ -1,0 +1,32 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ApiRequestOptions } from "./ApiRequestOptions";
+
+type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
+type Headers = Record<string, string>;
+
+export type OpenAPIConfig = {
+  BASE: string;
+  VERSION: string;
+  WITH_CREDENTIALS: boolean;
+  CREDENTIALS: "include" | "omit" | "same-origin";
+  TOKEN?: string | Resolver<string> | undefined;
+  USERNAME?: string | Resolver<string> | undefined;
+  PASSWORD?: string | Resolver<string> | undefined;
+  HEADERS?: Headers | Resolver<Headers> | undefined;
+  ENCODE_PATH?: ((path: string) => string) | undefined;
+};
+
+export const OpenAPI: OpenAPIConfig = {
+  BASE: "https://forge.sindri.app",
+  VERSION: "1.5.6",
+  WITH_CREDENTIALS: false,
+  CREDENTIALS: "include",
+  TOKEN: undefined,
+  USERNAME: undefined,
+  PASSWORD: undefined,
+  HEADERS: undefined,
+  ENCODE_PATH: undefined,
+};

--- a/src/lib/api/core/request.ts
+++ b/src/lib/api/core/request.ts
@@ -1,0 +1,364 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import axios from "axios";
+import type {
+  AxiosError,
+  AxiosRequestConfig,
+  AxiosResponse,
+  AxiosInstance,
+} from "axios";
+import FormData from "form-data";
+
+import { ApiError } from "./ApiError";
+import type { ApiRequestOptions } from "./ApiRequestOptions";
+import type { ApiResult } from "./ApiResult";
+import { CancelablePromise } from "./CancelablePromise";
+import type { OnCancel } from "./CancelablePromise";
+import type { OpenAPIConfig } from "./OpenAPI";
+
+export const isDefined = <T>(
+  value: T | null | undefined,
+): value is Exclude<T, null | undefined> => {
+  return value !== undefined && value !== null;
+};
+
+export const isString = (value: any): value is string => {
+  return typeof value === "string";
+};
+
+export const isStringWithValue = (value: any): value is string => {
+  return isString(value) && value !== "";
+};
+
+export const isBlob = (value: any): value is Blob => {
+  return (
+    typeof value === "object" &&
+    typeof value.type === "string" &&
+    typeof value.stream === "function" &&
+    typeof value.arrayBuffer === "function" &&
+    typeof value.constructor === "function" &&
+    typeof value.constructor.name === "string" &&
+    /^(Blob|File)$/.test(value.constructor.name) &&
+    /^(Blob|File)$/.test(value[Symbol.toStringTag])
+  );
+};
+
+export const isFormData = (value: any): value is FormData => {
+  return value instanceof FormData;
+};
+
+export const isSuccess = (status: number): boolean => {
+  return status >= 200 && status < 300;
+};
+
+export const base64 = (str: string): string => {
+  try {
+    return btoa(str);
+  } catch (err) {
+    // @ts-ignore
+    return Buffer.from(str).toString("base64");
+  }
+};
+
+export const getQueryString = (params: Record<string, any>): string => {
+  const qs: string[] = [];
+
+  const append = (key: string, value: any) => {
+    qs.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
+  };
+
+  const process = (key: string, value: any) => {
+    if (isDefined(value)) {
+      if (Array.isArray(value)) {
+        value.forEach((v) => {
+          process(key, v);
+        });
+      } else if (typeof value === "object") {
+        Object.entries(value).forEach(([k, v]) => {
+          process(`${key}[${k}]`, v);
+        });
+      } else {
+        append(key, value);
+      }
+    }
+  };
+
+  Object.entries(params).forEach(([key, value]) => {
+    process(key, value);
+  });
+
+  if (qs.length > 0) {
+    return `?${qs.join("&")}`;
+  }
+
+  return "";
+};
+
+const getUrl = (config: OpenAPIConfig, options: ApiRequestOptions): string => {
+  const encoder = config.ENCODE_PATH || encodeURI;
+
+  const path = options.url
+    .replace("{api-version}", config.VERSION)
+    .replace(/{(.*?)}/g, (substring: string, group: string) => {
+      if (options.path?.hasOwnProperty(group)) {
+        return encoder(String(options.path[group]));
+      }
+      return substring;
+    });
+
+  const url = `${config.BASE}${path}`;
+  if (options.query) {
+    return `${url}${getQueryString(options.query)}`;
+  }
+  return url;
+};
+
+export const getFormData = (
+  options: ApiRequestOptions,
+): FormData | undefined => {
+  if (options.formData) {
+    const formData = new FormData();
+
+    const process = (key: string, value: any) => {
+      if (isString(value) || isBlob(value)) {
+        formData.append(key, value);
+      } else {
+        formData.append(key, JSON.stringify(value));
+      }
+    };
+
+    Object.entries(options.formData)
+      .filter(([_, value]) => isDefined(value))
+      .forEach(([key, value]) => {
+        if (Array.isArray(value)) {
+          value.forEach((v) => process(key, v));
+        } else {
+          process(key, value);
+        }
+      });
+
+    return formData;
+  }
+  return undefined;
+};
+
+type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
+
+export const resolve = async <T>(
+  options: ApiRequestOptions,
+  resolver?: T | Resolver<T>,
+): Promise<T | undefined> => {
+  if (typeof resolver === "function") {
+    return (resolver as Resolver<T>)(options);
+  }
+  return resolver;
+};
+
+export const getHeaders = async (
+  config: OpenAPIConfig,
+  options: ApiRequestOptions,
+  formData?: FormData,
+): Promise<Record<string, string>> => {
+  const token = await resolve(options, config.TOKEN);
+  const username = await resolve(options, config.USERNAME);
+  const password = await resolve(options, config.PASSWORD);
+  const additionalHeaders = await resolve(options, config.HEADERS);
+  const formHeaders =
+    (typeof formData?.getHeaders === "function" && formData?.getHeaders()) ||
+    {};
+
+  const headers = Object.entries({
+    Accept: "application/json",
+    ...additionalHeaders,
+    ...options.headers,
+    ...formHeaders,
+  })
+    .filter(([_, value]) => isDefined(value))
+    .reduce(
+      (headers, [key, value]) => ({
+        ...headers,
+        [key]: String(value),
+      }),
+      {} as Record<string, string>,
+    );
+
+  if (isStringWithValue(token)) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+
+  if (isStringWithValue(username) && isStringWithValue(password)) {
+    const credentials = base64(`${username}:${password}`);
+    headers["Authorization"] = `Basic ${credentials}`;
+  }
+
+  if (options.body) {
+    if (options.mediaType) {
+      headers["Content-Type"] = options.mediaType;
+    } else if (isBlob(options.body)) {
+      headers["Content-Type"] = options.body.type || "application/octet-stream";
+    } else if (isString(options.body)) {
+      headers["Content-Type"] = "text/plain";
+    } else if (!isFormData(options.body)) {
+      headers["Content-Type"] = "application/json";
+    }
+  }
+
+  return headers;
+};
+
+export const getRequestBody = (options: ApiRequestOptions): any => {
+  if (options.body) {
+    return options.body;
+  }
+  return undefined;
+};
+
+export const sendRequest = async <T>(
+  config: OpenAPIConfig,
+  options: ApiRequestOptions,
+  url: string,
+  body: any,
+  formData: FormData | undefined,
+  headers: Record<string, string>,
+  onCancel: OnCancel,
+  axiosClient: AxiosInstance,
+): Promise<AxiosResponse<T>> => {
+  const source = axios.CancelToken.source();
+
+  const requestConfig: AxiosRequestConfig = {
+    url,
+    headers,
+    data: body ?? formData,
+    method: options.method,
+    withCredentials: config.WITH_CREDENTIALS,
+    cancelToken: source.token,
+  };
+
+  onCancel(() => source.cancel("The user aborted a request."));
+
+  try {
+    return await axiosClient.request(requestConfig);
+  } catch (error) {
+    const axiosError = error as AxiosError<T>;
+    if (axiosError.response) {
+      return axiosError.response;
+    }
+    throw error;
+  }
+};
+
+export const getResponseHeader = (
+  response: AxiosResponse<any>,
+  responseHeader?: string,
+): string | undefined => {
+  if (responseHeader) {
+    const content = response.headers[responseHeader];
+    if (isString(content)) {
+      return content;
+    }
+  }
+  return undefined;
+};
+
+export const getResponseBody = (response: AxiosResponse<any>): any => {
+  if (response.status !== 204) {
+    return response.data;
+  }
+  return undefined;
+};
+
+export const catchErrorCodes = (
+  options: ApiRequestOptions,
+  result: ApiResult,
+): void => {
+  const errors: Record<number, string> = {
+    400: "Bad Request",
+    401: "Unauthorized",
+    403: "Forbidden",
+    404: "Not Found",
+    500: "Internal Server Error",
+    502: "Bad Gateway",
+    503: "Service Unavailable",
+    ...options.errors,
+  };
+
+  const error = errors[result.status];
+  if (error) {
+    throw new ApiError(options, result, error);
+  }
+
+  if (!result.ok) {
+    const errorStatus = result.status ?? "unknown";
+    const errorStatusText = result.statusText ?? "unknown";
+    const errorBody = (() => {
+      try {
+        return JSON.stringify(result.body, null, 2);
+      } catch (e) {
+        return undefined;
+      }
+    })();
+
+    throw new ApiError(
+      options,
+      result,
+      `Generic Error: status: ${errorStatus}; status text: ${errorStatusText}; body: ${errorBody}`,
+    );
+  }
+};
+
+/**
+ * Request method
+ * @param config The OpenAPI configuration object
+ * @param options The request options from the service
+ * @param axiosClient The axios client instance to use
+ * @returns CancelablePromise<T>
+ * @throws ApiError
+ */
+export const request = <T>(
+  config: OpenAPIConfig,
+  options: ApiRequestOptions,
+  axiosClient: AxiosInstance = axios,
+): CancelablePromise<T> => {
+  return new CancelablePromise(async (resolve, reject, onCancel) => {
+    try {
+      const url = getUrl(config, options);
+      const formData = getFormData(options);
+      const body = getRequestBody(options);
+      const headers = await getHeaders(config, options, formData);
+
+      if (!onCancel.isCancelled) {
+        const response = await sendRequest<T>(
+          config,
+          options,
+          url,
+          body,
+          formData,
+          headers,
+          onCancel,
+          axiosClient,
+        );
+        const responseBody = getResponseBody(response);
+        const responseHeader = getResponseHeader(
+          response,
+          options.responseHeader,
+        );
+
+        const result: ApiResult = {
+          url,
+          ok: isSuccess(response.status),
+          status: response.status,
+          statusText: response.statusText,
+          body: responseHeader ?? responseBody,
+        };
+
+        catchErrorCodes(options, result);
+
+        resolve(result.body);
+      }
+    } catch (error) {
+      reject(error);
+    }
+  });
+};

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -1,0 +1,42 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+export { ApiError } from './core/ApiError';
+export { CancelablePromise, CancelError } from './core/CancelablePromise';
+export { OpenAPI } from './core/OpenAPI';
+export type { OpenAPIConfig } from './core/OpenAPI';
+
+export type { ActionResponse } from './models/ActionResponse';
+export type { APIKeyErrorResponse } from './models/APIKeyErrorResponse';
+export type { APIKeyResponse } from './models/APIKeyResponse';
+export type { CircomCircuitInfoResponse } from './models/CircomCircuitInfoResponse';
+export { CircomCircuitType } from './models/CircomCircuitType';
+export type { CircuitDoesNotExistResponse } from './models/CircuitDoesNotExistResponse';
+export { CircuitStatus } from './models/CircuitStatus';
+export { CircuitType } from './models/CircuitType';
+export type { ComingSoonResponse } from './models/ComingSoonResponse';
+export type { ForgeInternalErrorResponse } from './models/ForgeInternalErrorResponse';
+export type { ForgeInvalidUploadResponse } from './models/ForgeInvalidUploadResponse';
+export type { ForgeObtainApikeyInput } from './models/ForgeObtainApikeyInput';
+export type { GnarkCircuitInfoResponse } from './models/GnarkCircuitInfoResponse';
+export { GnarkCircuitType } from './models/GnarkCircuitType';
+export type { Halo2CircuitInfoResponse } from './models/Halo2CircuitInfoResponse';
+export { Halo2CircuitType } from './models/Halo2CircuitType';
+export type { ProofCannotBeCreatedResponse } from './models/ProofCannotBeCreatedResponse';
+export type { ProofDoesNotExistResponse } from './models/ProofDoesNotExistResponse';
+export type { ProofIdResponse } from './models/ProofIdResponse';
+export type { ProofInfoResponse } from './models/ProofInfoResponse';
+export { ProofStatus } from './models/ProofStatus';
+export type { Schema } from './models/Schema';
+export type { TokenObtainPairInputSchema } from './models/TokenObtainPairInputSchema';
+export type { TokenObtainPairOutputSchema } from './models/TokenObtainPairOutputSchema';
+export type { TokenRefreshInputSchema } from './models/TokenRefreshInputSchema';
+export type { TokenRefreshOutputSchema } from './models/TokenRefreshOutputSchema';
+export type { TokenVerifyInputSchema } from './models/TokenVerifyInputSchema';
+export type { ValidationErrorResponse } from './models/ValidationErrorResponse';
+
+export { AuthorizationService } from './services/AuthorizationService';
+export { CircuitsService } from './services/CircuitsService';
+export { ProofsService } from './services/ProofsService';
+export { TokenService } from './services/TokenService';

--- a/src/lib/api/models/APIKeyErrorResponse.ts
+++ b/src/lib/api/models/APIKeyErrorResponse.ts
@@ -1,0 +1,13 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * Action: Attempt to fetch an API key with username and password.
+ * Error: User does not exist or password is incorrect.
+ */
+export type APIKeyErrorResponse = {
+  username: string;
+  message?: string;
+};

--- a/src/lib/api/models/APIKeyResponse.ts
+++ b/src/lib/api/models/APIKeyResponse.ts
@@ -1,0 +1,14 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * Response containing an API key.
+ *
+ * This key is used in conjunction with the APIKey model
+ * to authenticate users in the API.
+ */
+export type APIKeyResponse = {
+  api_key: string;
+};

--- a/src/lib/api/models/ActionResponse.ts
+++ b/src/lib/api/models/ActionResponse.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * Generic response for any client action.
+ * E.g. job submission, patch, delete
+ */
+export type ActionResponse = {
+  success?: boolean;
+};

--- a/src/lib/api/models/CircomCircuitInfoResponse.ts
+++ b/src/lib/api/models/CircomCircuitInfoResponse.ts
@@ -1,0 +1,34 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { CircomCircuitType } from "./CircomCircuitType";
+import type { CircuitStatus } from "./CircuitStatus";
+
+/**
+ * Response for getting Circom circuit info.
+ */
+export type CircomCircuitInfoResponse = {
+  circuit_id: string;
+  circuit_name: string;
+  date_created: string;
+  status: CircuitStatus;
+  compute_time?: number;
+  compute_times?: any;
+  file_sizes?: Record<string, any>;
+  metadata?: Record<string, any>;
+  system_info?: Record<string, any>;
+  verification_key?: Record<string, any>;
+  error?: string;
+  circuit_type: CircomCircuitType;
+  curve?: string;
+  degree?: number;
+  num_constraints?: number;
+  num_outputs?: number;
+  num_private_inputs?: number;
+  num_public_inputs?: number;
+  num_wires?: number;
+  trusted_setup_file?: string;
+  witness_executable?: string;
+};

--- a/src/lib/api/models/CircomCircuitType.ts
+++ b/src/lib/api/models/CircomCircuitType.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * CircomType choices
+ */
+export enum CircomCircuitType {
+  CIRCOM = "Circom",
+}

--- a/src/lib/api/models/CircuitDoesNotExistResponse.ts
+++ b/src/lib/api/models/CircuitDoesNotExistResponse.ts
@@ -1,0 +1,14 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * Action: Attempt to fetch a circuit with circuit_name.
+ * Error: A circuit with circuit_name does not exist.
+ */
+export type CircuitDoesNotExistResponse = {
+  error: string;
+  circuit_id: string;
+  message: string;
+};

--- a/src/lib/api/models/CircuitStatus.ts
+++ b/src/lib/api/models/CircuitStatus.ts
@@ -1,0 +1,15 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * CircuitStatus choices
+ */
+export enum CircuitStatus {
+  CREATED = "Created",
+  QUEUED = "Queued",
+  IN_PROGRESS = "In Progress",
+  READY = "Ready",
+  FAILED = "Failed",
+}

--- a/src/lib/api/models/CircuitType.ts
+++ b/src/lib/api/models/CircuitType.ts
@@ -1,0 +1,13 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * CircuitType choices
+ */
+export enum CircuitType {
+  CIRCOM = "Circom",
+  HALO2 = "Halo2",
+  GNARK = "Gnark",
+}

--- a/src/lib/api/models/ComingSoonResponse.ts
+++ b/src/lib/api/models/ComingSoonResponse.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * Response for NotImplementedError
+ */
+export type ComingSoonResponse = {
+  message?: string;
+};

--- a/src/lib/api/models/ForgeInternalErrorResponse.ts
+++ b/src/lib/api/models/ForgeInternalErrorResponse.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * Response for ForgeInternalError
+ */
+export type ForgeInternalErrorResponse = {
+  error: string;
+  message?: string;
+};

--- a/src/lib/api/models/ForgeInvalidUploadResponse.ts
+++ b/src/lib/api/models/ForgeInvalidUploadResponse.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * Response for ForgeInvalidUploadError
+ */
+export type ForgeInvalidUploadResponse = {
+  error: string;
+  message?: string;
+};

--- a/src/lib/api/models/ForgeObtainApikeyInput.ts
+++ b/src/lib/api/models/ForgeObtainApikeyInput.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * Client input to obtain an API key.
+ */
+export type ForgeObtainApikeyInput = {
+  username: string;
+  password: string;
+};

--- a/src/lib/api/models/GnarkCircuitInfoResponse.ts
+++ b/src/lib/api/models/GnarkCircuitInfoResponse.ts
@@ -1,0 +1,26 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { CircuitStatus } from "./CircuitStatus";
+import type { GnarkCircuitType } from "./GnarkCircuitType";
+
+/**
+ * Response for getting Gnark circuit info.
+ */
+export type GnarkCircuitInfoResponse = {
+  circuit_id: string;
+  circuit_name: string;
+  date_created: string;
+  status: CircuitStatus;
+  compute_time?: number;
+  compute_times?: any;
+  file_sizes?: Record<string, any>;
+  metadata?: Record<string, any>;
+  system_info?: Record<string, any>;
+  verification_key?: Record<string, any>;
+  error?: string;
+  circuit_type: GnarkCircuitType;
+  curve?: string;
+};

--- a/src/lib/api/models/GnarkCircuitType.ts
+++ b/src/lib/api/models/GnarkCircuitType.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * GnarkType choices
+ */
+export enum GnarkCircuitType {
+  GNARK = "Gnark",
+}

--- a/src/lib/api/models/Halo2CircuitInfoResponse.ts
+++ b/src/lib/api/models/Halo2CircuitInfoResponse.ts
@@ -1,0 +1,29 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { CircuitStatus } from "./CircuitStatus";
+import type { Halo2CircuitType } from "./Halo2CircuitType";
+
+/**
+ * Response for getting Halo2 circuit info.
+ */
+export type Halo2CircuitInfoResponse = {
+  circuit_id: string;
+  circuit_name: string;
+  date_created: string;
+  status: CircuitStatus;
+  compute_time?: number;
+  compute_times?: any;
+  file_sizes?: Record<string, any>;
+  metadata?: Record<string, any>;
+  system_info?: Record<string, any>;
+  verification_key?: Record<string, any>;
+  error?: string;
+  circuit_type: Halo2CircuitType;
+  curve?: string;
+  degree?: number;
+  trusted_setup_file?: string;
+  halo2_base_version?: string;
+};

--- a/src/lib/api/models/Halo2CircuitType.ts
+++ b/src/lib/api/models/Halo2CircuitType.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * Halo2Type choices
+ */
+export enum Halo2CircuitType {
+  HALO2 = "Halo2",
+}

--- a/src/lib/api/models/ProofCannotBeCreatedResponse.ts
+++ b/src/lib/api/models/ProofCannotBeCreatedResponse.ts
@@ -1,0 +1,14 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * Action: Attempt to create a proof with invalid input.
+ * Error: The proof cannot be created with the given input.
+ */
+export type ProofCannotBeCreatedResponse = {
+  error: string;
+  circuit_id: string;
+  message?: string;
+};

--- a/src/lib/api/models/ProofDoesNotExistResponse.ts
+++ b/src/lib/api/models/ProofDoesNotExistResponse.ts
@@ -1,0 +1,14 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * Action: Attempt to fetch a proof with proof_id.
+ * Error: Proof with proof_id does not exist.
+ */
+export type ProofDoesNotExistResponse = {
+  error: string;
+  proof_id: string;
+  message: string;
+};

--- a/src/lib/api/models/ProofIdResponse.ts
+++ b/src/lib/api/models/ProofIdResponse.ts
@@ -1,0 +1,11 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * Response containing a proof ID.
+ */
+export type ProofIdResponse = {
+  proof_id: string;
+};

--- a/src/lib/api/models/ProofInfoResponse.ts
+++ b/src/lib/api/models/ProofInfoResponse.ts
@@ -1,0 +1,31 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+import type { CircuitType } from "./CircuitType";
+import type { ProofStatus } from "./ProofStatus";
+
+/**
+ * Response for getting proof info.
+ */
+export type ProofInfoResponse = {
+  proof_id: string;
+  circuit_name: string;
+  circuit_id: string;
+  circuit_type: CircuitType;
+  date_created: string;
+  perform_verify: boolean;
+  status: ProofStatus;
+  compute_time?: number;
+  compute_times?: any;
+  file_sizes?: Record<string, any>;
+  metadata?: Record<string, any>;
+  proof_input?: Record<string, any>;
+  proof?: Record<string, any>;
+  prover_implementation?: Record<string, any>;
+  public?: any;
+  system_info?: Record<string, any>;
+  verification_key?: Record<string, any>;
+  error?: string;
+};

--- a/src/lib/api/models/ProofStatus.ts
+++ b/src/lib/api/models/ProofStatus.ts
@@ -1,0 +1,14 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+/**
+ * ProofStatus choices
+ */
+export enum ProofStatus {
+  QUEUED = "Queued",
+  IN_PROGRESS = "In Progress",
+  READY = "Ready",
+  FAILED = "Failed",
+}

--- a/src/lib/api/models/Schema.ts
+++ b/src/lib/api/models/Schema.ts
@@ -1,0 +1,6 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type Schema = {};

--- a/src/lib/api/models/TokenObtainPairInputSchema.ts
+++ b/src/lib/api/models/TokenObtainPairInputSchema.ts
@@ -1,0 +1,12 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type TokenObtainPairInputSchema = {
+  password: string;
+  /**
+   * Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only.
+   */
+  username: string;
+};

--- a/src/lib/api/models/TokenObtainPairOutputSchema.ts
+++ b/src/lib/api/models/TokenObtainPairOutputSchema.ts
@@ -1,0 +1,13 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type TokenObtainPairOutputSchema = {
+  /**
+   * Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only.
+   */
+  username: string;
+  refresh: string;
+  access: string;
+};

--- a/src/lib/api/models/TokenRefreshInputSchema.ts
+++ b/src/lib/api/models/TokenRefreshInputSchema.ts
@@ -1,0 +1,8 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type TokenRefreshInputSchema = {
+  refresh: string;
+};

--- a/src/lib/api/models/TokenRefreshOutputSchema.ts
+++ b/src/lib/api/models/TokenRefreshOutputSchema.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type TokenRefreshOutputSchema = {
+  refresh: string;
+  access?: string;
+};

--- a/src/lib/api/models/TokenVerifyInputSchema.ts
+++ b/src/lib/api/models/TokenVerifyInputSchema.ts
@@ -1,0 +1,8 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type TokenVerifyInputSchema = {
+  token: string;
+};

--- a/src/lib/api/models/ValidationErrorResponse.ts
+++ b/src/lib/api/models/ValidationErrorResponse.ts
@@ -1,0 +1,9 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type ValidationErrorResponse = {
+  location: string;
+  message: string;
+};

--- a/src/lib/api/services/AuthorizationService.ts
+++ b/src/lib/api/services/AuthorizationService.ts
@@ -1,0 +1,46 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { APIKeyResponse } from "../models/APIKeyResponse";
+import type { ForgeObtainApikeyInput } from "../models/ForgeObtainApikeyInput";
+
+import type { CancelablePromise } from "../core/CancelablePromise";
+import { OpenAPI } from "../core/OpenAPI";
+import { request as __request } from "../core/request";
+
+export class AuthorizationService {
+  /**
+   * Generate API Key
+   * Generates a long-term API Key from your account's username and password.
+   * @param requestBody
+   * @returns APIKeyResponse OK
+   * @throws ApiError
+   */
+  public static apikeyGenerate(
+    requestBody: ForgeObtainApikeyInput,
+  ): CancelablePromise<APIKeyResponse> {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/api/apikey/generate",
+      body: requestBody,
+      mediaType: "application/json",
+      errors: {
+        401: `Unauthorized`,
+      },
+    });
+  }
+
+  /**
+   * Generate long-term API Key (requires prior authentication)
+   * Return a long-term API key for the user. This will replace the user's existing API key!
+   * @returns APIKeyResponse OK
+   * @throws ApiError
+   */
+  public static apikeyGenerateWithAuth(): CancelablePromise<APIKeyResponse> {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/api/v1/apikey/generate",
+    });
+  }
+}

--- a/src/lib/api/services/CircuitsService.ts
+++ b/src/lib/api/services/CircuitsService.ts
@@ -1,0 +1,239 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ActionResponse } from "../models/ActionResponse";
+import type { CircomCircuitInfoResponse } from "../models/CircomCircuitInfoResponse";
+import type { GnarkCircuitInfoResponse } from "../models/GnarkCircuitInfoResponse";
+import type { Halo2CircuitInfoResponse } from "../models/Halo2CircuitInfoResponse";
+import type { ProofIdResponse } from "../models/ProofIdResponse";
+import type { ProofInfoResponse } from "../models/ProofInfoResponse";
+
+import type { CancelablePromise } from "../core/CancelablePromise";
+import { OpenAPI } from "../core/OpenAPI";
+import { request as __request } from "../core/request";
+
+export class CircuitsService {
+  /**
+   * Circuit List
+   * Return a list of CircuitInfoResponse for circuits related to user.
+   * @param includeVerificationKey
+   * @returns any OK
+   * @throws ApiError
+   */
+  public static circuitList(
+    includeVerificationKey: boolean = false,
+  ): CancelablePromise<
+    Array<
+      | CircomCircuitInfoResponse
+      | Halo2CircuitInfoResponse
+      | GnarkCircuitInfoResponse
+    >
+  > {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/api/v1/circuit/list",
+      query: {
+        include_verification_key: includeVerificationKey,
+      },
+      errors: {
+        500: `Internal Server Error`,
+      },
+    });
+  }
+
+  /**
+   * Create Circuit
+   * Create a circuit.
+   * @param formData
+   * @returns any Created
+   * @throws ApiError
+   */
+  public static circuitCreate(formData: {
+    circuit_name: string;
+    /**
+     * CircuitType choices
+     */
+    circuit_type: "Circom" | "Halo2" | "Gnark";
+  }): CancelablePromise<
+    | CircomCircuitInfoResponse
+    | Halo2CircuitInfoResponse
+    | GnarkCircuitInfoResponse
+  > {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/api/v1/circuit/create",
+      formData: formData,
+      mediaType: "application/x-www-form-urlencoded",
+      errors: {
+        422: `Unprocessable Entity`,
+        500: `Internal Server Error`,
+        501: `Not Implemented`,
+      },
+    });
+  }
+
+  /**
+   * Circuit Detail
+   * Get info for existing circuit
+   * @param circuitId
+   * @param includeVerificationKey
+   * @returns any OK
+   * @throws ApiError
+   */
+  public static circuitDetail(
+    circuitId: string,
+    includeVerificationKey: boolean = true,
+  ): CancelablePromise<
+    | CircomCircuitInfoResponse
+    | Halo2CircuitInfoResponse
+    | GnarkCircuitInfoResponse
+  > {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/api/v1/circuit/{circuit_id}/detail",
+      path: {
+        circuit_id: circuitId,
+      },
+      query: {
+        include_verification_key: includeVerificationKey,
+      },
+      errors: {
+        404: `Not Found`,
+        500: `Internal Server Error`,
+      },
+    });
+  }
+
+  /**
+   * Compile Circuit
+   * Compile a circuit.
+   * @param circuitId
+   * @returns ActionResponse Created
+   * @throws ApiError
+   */
+  public static circuitCompile(
+    circuitId: string,
+  ): CancelablePromise<ActionResponse> {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/api/v1/circuit/{circuit_id}/compile",
+      path: {
+        circuit_id: circuitId,
+      },
+      errors: {
+        404: `Not Found`,
+        501: `Not Implemented`,
+      },
+    });
+  }
+
+  /**
+   * Circuit Proofs
+   * Return list of ProofInfoResponse for proofs of circuit_id related to user.
+   * @param circuitId
+   * @param includeProofInput
+   * @param includeProof
+   * @param includePublic
+   * @param includeVerificationKey
+   * @returns ProofInfoResponse OK
+   * @throws ApiError
+   */
+  public static circuitProofs(
+    circuitId: string,
+    includeProofInput: boolean = false,
+    includeProof: boolean = false,
+    includePublic: boolean = false,
+    includeVerificationKey: boolean = false,
+  ): CancelablePromise<Array<ProofInfoResponse>> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/api/v1/circuit/{circuit_id}/proofs",
+      path: {
+        circuit_id: circuitId,
+      },
+      query: {
+        include_proof_input: includeProofInput,
+        include_proof: includeProof,
+        include_public: includePublic,
+        include_verification_key: includeVerificationKey,
+      },
+      errors: {
+        404: `Not Found`,
+        500: `Internal Server Error`,
+      },
+    });
+  }
+
+  /**
+   * Create Proof for Circuit
+   * Prove a circuit with specific inputs.
+   * @param circuitId
+   * @param formData
+   * @returns ProofIdResponse Created
+   * @throws ApiError
+   */
+  public static proofCreate(
+    circuitId: string,
+    formData: {
+      /**
+       * JSON-serialized string for the proof input.
+       */
+      proof_input: string;
+      /**
+       * Perform an internal verification on the resulting proof.
+       */
+      perform_verify?: boolean;
+      /**
+       * Internal prover implementation setting.
+       */
+      prover_implementation?: string;
+    },
+  ): CancelablePromise<ProofIdResponse> {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/api/v1/circuit/{circuit_id}/prove",
+      path: {
+        circuit_id: circuitId,
+      },
+      formData: formData,
+      mediaType: "application/x-www-form-urlencoded",
+      errors: {
+        404: `Not Found`,
+        412: `Precondition Failed`,
+        501: `Not Implemented`,
+      },
+    });
+  }
+
+  /**
+   * Upload Files for Circuit
+   * Upload files for a circuit. We only allow 1 file for now, and it must be a Tarfile.
+   * @param circuitId
+   * @param formData
+   * @returns ActionResponse Created
+   * @throws ApiError
+   */
+  public static circuitUploadfiles(
+    circuitId: string,
+    formData: {
+      files: Array<Blob>;
+    },
+  ): CancelablePromise<ActionResponse> {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/api/v1/circuit/{circuit_id}/uploadfiles",
+      path: {
+        circuit_id: circuitId,
+      },
+      formData: formData,
+      mediaType: "multipart/form-data",
+      errors: {
+        404: `Not Found`,
+        412: `Precondition Failed`,
+        500: `Internal Server Error`,
+        501: `Not Implemented`,
+      },
+    });
+  }
+}

--- a/src/lib/api/services/ProofsService.ts
+++ b/src/lib/api/services/ProofsService.ts
@@ -1,0 +1,79 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { ProofInfoResponse } from "../models/ProofInfoResponse";
+
+import type { CancelablePromise } from "../core/CancelablePromise";
+import { OpenAPI } from "../core/OpenAPI";
+import { request as __request } from "../core/request";
+
+export class ProofsService {
+  /**
+   * Proof List
+   * Return list of ProofInfoResponse for proofs related to user.
+   * @param includeProofInput
+   * @param includeProof
+   * @param includePublic
+   * @param includeVerificationKey
+   * @returns ProofInfoResponse OK
+   * @throws ApiError
+   */
+  public static proofList(
+    includeProofInput: boolean = false,
+    includeProof: boolean = false,
+    includePublic: boolean = false,
+    includeVerificationKey: boolean = false,
+  ): CancelablePromise<Array<ProofInfoResponse>> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/api/v1/proof/list",
+      query: {
+        include_proof_input: includeProofInput,
+        include_proof: includeProof,
+        include_public: includePublic,
+        include_verification_key: includeVerificationKey,
+      },
+      errors: {
+        500: `Internal Server Error`,
+      },
+    });
+  }
+
+  /**
+   * Proof Detail
+   * Get info for existing proof
+   * @param proofId
+   * @param includeProofInput
+   * @param includeProof
+   * @param includePublic
+   * @param includeVerificationKey
+   * @returns ProofInfoResponse OK
+   * @throws ApiError
+   */
+  public static proofDetail(
+    proofId: string,
+    includeProofInput: boolean = true,
+    includeProof: boolean = true,
+    includePublic: boolean = true,
+    includeVerificationKey: boolean = true,
+  ): CancelablePromise<ProofInfoResponse> {
+    return __request(OpenAPI, {
+      method: "GET",
+      url: "/api/v1/proof/{proof_id}/detail",
+      path: {
+        proof_id: proofId,
+      },
+      query: {
+        include_proof_input: includeProofInput,
+        include_proof: includeProof,
+        include_public: includePublic,
+        include_verification_key: includeVerificationKey,
+      },
+      errors: {
+        404: `Not Found`,
+        500: `Internal Server Error`,
+      },
+    });
+  }
+}

--- a/src/lib/api/services/TokenService.ts
+++ b/src/lib/api/services/TokenService.ts
@@ -1,0 +1,67 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+import type { Schema } from "../models/Schema";
+import type { TokenObtainPairInputSchema } from "../models/TokenObtainPairInputSchema";
+import type { TokenObtainPairOutputSchema } from "../models/TokenObtainPairOutputSchema";
+import type { TokenRefreshInputSchema } from "../models/TokenRefreshInputSchema";
+import type { TokenRefreshOutputSchema } from "../models/TokenRefreshOutputSchema";
+import type { TokenVerifyInputSchema } from "../models/TokenVerifyInputSchema";
+
+import type { CancelablePromise } from "../core/CancelablePromise";
+import { OpenAPI } from "../core/OpenAPI";
+import { request as __request } from "../core/request";
+
+export class TokenService {
+  /**
+   * Obtain Token
+   * @param requestBody
+   * @returns TokenObtainPairOutputSchema OK
+   * @throws ApiError
+   */
+  public static c04Ee8ControllerObtainToken(
+    requestBody: TokenObtainPairInputSchema,
+  ): CancelablePromise<TokenObtainPairOutputSchema> {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/api/token/pair",
+      body: requestBody,
+      mediaType: "application/json",
+    });
+  }
+
+  /**
+   * Refresh Token
+   * @param requestBody
+   * @returns TokenRefreshOutputSchema OK
+   * @throws ApiError
+   */
+  public static e8136B3ControllerRefreshToken(
+    requestBody: TokenRefreshInputSchema,
+  ): CancelablePromise<TokenRefreshOutputSchema> {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/api/token/refresh",
+      body: requestBody,
+      mediaType: "application/json",
+    });
+  }
+
+  /**
+   * Verify Token
+   * @param requestBody
+   * @returns Schema OK
+   * @throws ApiError
+   */
+  public static ecdControllerVerifyToken(
+    requestBody: TokenVerifyInputSchema,
+  ): CancelablePromise<Schema> {
+    return __request(OpenAPI, {
+      method: "POST",
+      url: "/api/token/verify",
+      body: requestBody,
+      mediaType: "application/json",
+    });
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "@tsconfig/node18/tsconfig.json",
   "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "lib": ["dom"],
     "preserveConstEnums": true
   },
   "include": ["src/**/*"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,16 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
+"@apidevtools/json-schema-ref-parser@9.0.9":
+  version "9.0.9"
+  resolved "https://registry.yarnpkg.com/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz#d720f9256e3609621280584f2b47ae165359268b"
+  integrity sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==
+  dependencies:
+    "@jsdevtools/ono" "^7.1.3"
+    "@types/json-schema" "^7.0.6"
+    call-me-maybe "^1.0.1"
+    js-yaml "^4.1.0"
+
 "@esbuild/android-arm64@0.19.5":
   version "0.19.5"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.19.5.tgz#276c5f99604054d3dbb733577e09adae944baa90"
@@ -200,6 +210,11 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@jsdevtools/ono@^7.1.3":
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/@jsdevtools/ono/-/ono-7.1.3.tgz#9df03bbd7c696a5c58885c34aa06da41c8543796"
+  integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -298,7 +313,7 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node18/-/node18-18.2.2.tgz#81fb16ecff0d400b1cbadbf76713b50f331029ce"
   integrity sha512-d6McJeGsuoRlwWZmVIeE8CUA27lu6jLjvv1JzqmpsytOYYbVi1tHZEnwCNVOXnj4pyLvneZlFlpXUK+X9wBWyw==
 
-"@types/json-schema@^7.0.12":
+"@types/json-schema@^7.0.12", "@types/json-schema@^7.0.6":
   version "7.0.15"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
@@ -516,10 +531,20 @@ cac@^6.7.12:
   resolved "https://registry.yarnpkg.com/cac/-/cac-6.7.14.tgz#804e1e6f506ee363cb0e3ccbb09cad5dd9870959"
   integrity sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==
 
+call-me-maybe@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.2.tgz#03f964f19522ba643b1b0693acb9152fe2074baa"
+  integrity sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==
+
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
+
+camelcase@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
+  integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 chalk@^4.0.0:
   version "4.1.2"
@@ -555,6 +580,11 @@ color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+commander@^11.0.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-11.1.0.tgz#62fdce76006a68e5c1ab3314dc92e800eb83d906"
+  integrity sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==
 
 commander@^4.0.0:
   version "4.1.1"
@@ -864,6 +894,15 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz#7eb4c67ca1ba34232ca9d2d93e9886e611ad7daf"
   integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
 
+fs-extra@^11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.1.1.tgz#da69f7c39f3b002378b0954bb6ae7efdc0876e2d"
+  integrity sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -936,10 +975,27 @@ globby@^11.0.3, globby@^11.1.0:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
+graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+  version "4.2.11"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
+  integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
+
 graphemer@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
+
+handlebars@^4.7.7:
+  version "4.7.8"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.8.tgz#41c42c18b1be2365439188c77c6afae71c0cd9e9"
+  integrity sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==
+  dependencies:
+    minimist "^1.2.5"
+    neo-async "^2.6.2"
+    source-map "^0.6.1"
+    wordwrap "^1.0.0"
+  optionalDependencies:
+    uglify-js "^3.1.4"
 
 has-flag@^4.0.0:
   version "4.0.0"
@@ -1072,6 +1128,13 @@ json-buffer@3.0.1:
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
   integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
 
+json-schema-ref-parser@^9.0.9:
+  version "9.0.9"
+  resolved "https://registry.yarnpkg.com/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz#66ea538e7450b12af342fa3d5b8458bc1e1e013f"
+  integrity sha512-qcP2lmGy+JUoQJ4DOQeLaZDqH9qSkeGCK3suKWxJXS82dg728Mn3j97azDMaOUmJAN4uCq91LdPx4K7E8F1a7Q==
+  dependencies:
+    "@apidevtools/json-schema-ref-parser" "9.0.9"
+
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
@@ -1081,6 +1144,15 @@ json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
+
+jsonfile@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
+  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+  dependencies:
+    universalify "^2.0.0"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 keyv@^4.5.3:
   version "4.5.4"
@@ -1171,6 +1243,11 @@ minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimist@^1.2.5:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
@@ -1189,6 +1266,11 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
+
+neo-async@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
+  integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
@@ -1244,6 +1326,17 @@ open@^9.1.0:
     define-lazy-prop "^3.0.0"
     is-inside-container "^1.0.0"
     is-wsl "^2.2.0"
+
+openapi-typescript-codegen@^0.25.0:
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/openapi-typescript-codegen/-/openapi-typescript-codegen-0.25.0.tgz#0cb028f54b33b0a63bd9da3756c1c41b4e1a70e2"
+  integrity sha512-nN/TnIcGbP58qYgwEEy5FrAAjePcYgfMaCe3tsmYyTgI3v4RR9v8os14L+LEWDvV50+CmqiyTzRkKKtJeb6Ybg==
+  dependencies:
+    camelcase "^6.3.0"
+    commander "^11.0.0"
+    fs-extra "^11.1.1"
+    handlebars "^4.7.7"
+    json-schema-ref-parser "^9.0.9"
 
 optionator@^0.9.3:
   version "0.9.3"
@@ -1451,6 +1544,11 @@ source-map@0.8.0-beta.0:
   dependencies:
     whatwg-url "^7.0.0"
 
+source-map@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
 strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
@@ -1596,10 +1694,20 @@ typescript@^5.2.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
   integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
+uglify-js@^3.1.4:
+  version "3.17.4"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.17.4.tgz#61678cf5fa3f5b7eb789bb345df29afb8257c22c"
+  integrity sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==
+
 undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+
+universalify@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
+  integrity sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==
 
 untildify@^4.0.0:
   version "4.0.0"
@@ -1633,6 +1741,11 @@ which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+wordwrap@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+  integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
 wrappy@1:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -475,6 +475,20 @@ array-union@^2.1.0:
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
+axios@^1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.2.tgz#de67d42c755b571d3e698df1b6504cde9b0ee9f2"
+  integrity sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==
+  dependencies:
+    follow-redirects "^1.15.0"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -581,6 +595,13 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@^11.0.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-11.1.0.tgz#62fdce76006a68e5c1ab3314dc92e800eb83d906"
@@ -639,6 +660,11 @@ define-lazy-prop@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz#dbb19adfb746d7fc6d734a06b72f4a00d021255f"
   integrity sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -893,6 +919,20 @@ flatted@^3.2.9:
   version "3.2.9"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz#7eb4c67ca1ba34232ca9d2d93e9886e611ad7daf"
   integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
+
+follow-redirects@^1.15.0:
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.3.tgz#fe2f3ef2690afce7e82ed0b44db08165b207123a"
+  integrity sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 fs-extra@^11.1.1:
   version "11.1.1"
@@ -1226,6 +1266,18 @@ micromatch@^4.0.4:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
@@ -1435,6 +1487,11 @@ prettier@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.1.0.tgz#c6d16474a5f764ea1a4a373c593b779697744d5e"
   integrity sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 punycode@^2.1.0:
   version "2.3.1"


### PR DESCRIPTION
This uses [openapi-typescript-codegen](https://www.npmjs.com/package/openapi-typescript-codegen) to generate an axios-based API client for the Sindri API. This can be generated using the `yarn generate-api` command. I haven't really tested this much at this point, but we'll see how it works as I start integrating it with the CLI.