### PR TITLE
Add logging and local development server support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ docker compose exec sindri-js bash
 
 From here, you can use the `sindri` command or run any of the Yarn invocations for linting, formatting, etc.
 
+#### Integrating With Local Development Server
+
+Inside of the Docker container, you can run
+
+```bash
+sindri -d login -u http://host.docker.internal login
+```
+
+to authenticate against a Sindri development backend running locally on port 80.
+Both your credentials and the local base URL for the server will be stored in `sindri.conf.json` and used in subsequent requests.
+
 ### Installing Dependencies
 
 To install the project dependencies:

--- a/compose.yaml
+++ b/compose.yaml
@@ -10,6 +10,9 @@ services:
         UID: "${UID:-1000}"
     command: ["/bin/sh", "-c", "yarn install && yarn build:watch"]
     init: true
+    network_mode: host
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     restart: unless-stopped
     volumes:
       - ./:/sindri/

--- a/package.json
+++ b/package.json
@@ -41,11 +41,12 @@
   "dependencies": {
     "@inquirer/prompts": "^3.3.0",
     "axios": "^1.6.2",
-    "chalk": "^4.1.2",
     "commander": "^11.1.0",
     "env-paths": "^2.2.1",
     "form-data": "^4.0.0",
     "lodash": "^4.17.21",
+    "pino": "^8.16.2",
+    "pino-pretty": "^10.2.3",
     "rc": "^1.2.8",
     "zod": "^3.22.4"
   },

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -1,10 +1,11 @@
 import fs from "fs";
 import path from "path";
 
-import chalk from "chalk";
 import envPaths from "env-paths";
 import { cloneDeep, merge } from "lodash";
 import { z } from "zod";
+
+import { logger } from "cli/logging";
 
 const paths = envPaths("sindri", {
   suffix: "",
@@ -30,28 +31,38 @@ const defaultConfig: ConfigSchema = ConfigSchema.parse({});
 
 const loadConfig = (): ConfigSchema => {
   if (fs.existsSync(configPath)) {
+    logger.debug(`Loading config from "${configPath}".`);
     try {
       const configFileContents: string = fs.readFileSync(configPath, {
         encoding: "utf-8",
       });
-      return ConfigSchema.parse(JSON.parse(configFileContents));
-    } catch {
-      console.warn(
-        chalk.yellow(
-          `The config schema in "${configPath}" is invalid and will not be used.\n` +
-            `To remove it and start fresh, run:\n    rm ${configPath}`,
-        ),
+      const loadedConfig = ConfigSchema.parse(JSON.parse(configFileContents));
+      logger.debug("Config loaded successfully.");
+      return loadedConfig;
+    } catch (error) {
+      logger.warn(
+        `The config schema in "${configPath}" is invalid and will not be used.\n` +
+          `To remove it and start fresh, run:\n    rm ${configPath}`,
       );
+      logger.debug(error);
     }
   }
+  logger.debug(
+    `Config file "${configPath}" does not exist, initializing default config.`,
+  );
   return cloneDeep(defaultConfig);
 };
 
-class Config {
-  protected _config: ConfigSchema;
+export class Config {
+  protected _config!: ConfigSchema;
+  protected static instance: Config;
 
   constructor() {
-    this._config = loadConfig();
+    if (!Config.instance) {
+      this._config = loadConfig();
+      Config.instance = this;
+    }
+    return Config.instance;
   }
 
   get auth(): ConfigSchema["auth"] {
@@ -60,6 +71,8 @@ class Config {
 
   update(configData: Partial<ConfigSchema>) {
     // Merge and validate the configs.
+    logger.debug("Merging in config update:");
+    logger.debug(configData);
     const newConfig: ConfigSchema = cloneDeep(this._config);
     merge(newConfig, configData);
     this._config = ConfigSchema.parse(newConfig);
@@ -71,10 +84,9 @@ class Config {
     }
 
     // Write out the new config.
+    logger.debug(`Writing merged config to "${configPath}":`, this._config);
     fs.writeFileSync(configPath, JSON.stringify(this._config, null, 2), {
       encoding: "utf-8",
     });
   }
 }
-
-export const config = new Config();

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import path from "path";
 
+import chalk from "chalk";
 import envPaths from "env-paths";
 import { cloneDeep, merge } from "lodash";
 import { z } from "zod";
@@ -16,6 +17,7 @@ const ConfigSchema = z.object({
     .nullable(
       z.object({
         apiKey: z.string(),
+        baseUrl: z.string().url(),
         teamId: z.number(),
         teamSlug: z.string(),
       }),
@@ -29,10 +31,19 @@ const defaultConfig: ConfigSchema = ConfigSchema.parse({});
 
 const loadConfig = (): ConfigSchema => {
   if (fs.existsSync(configPath)) {
-    const configFileContents: string = fs.readFileSync(configPath, {
-      encoding: "utf-8",
-    });
-    return ConfigSchema.parse(JSON.parse(configFileContents));
+    try {
+      const configFileContents: string = fs.readFileSync(configPath, {
+        encoding: "utf-8",
+      });
+      return ConfigSchema.parse(JSON.parse(configFileContents));
+    } catch {
+      console.warn(
+        chalk.yellow(
+          `The config schema in "${configPath}" is invalid and will not be used.\n` +
+            `To remove it and start fresh, run:\n    rm ${configPath}`,
+        ),
+      );
+    }
   }
   return cloneDeep(defaultConfig);
 };

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -10,7 +10,6 @@ const paths = envPaths("sindri", {
   suffix: "",
 });
 const configPath = path.join(paths.config, "sindri.conf.json");
-console.log(configPath);
 
 const ConfigSchema = z.object({
   auth: z

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,8 +1,10 @@
 #! /usr/bin/env node
-import { argv } from "process";
+import { argv, exit } from "process";
 
 import { Command } from "@commander-js/extra-typings";
 
+import { Config } from "cli/config";
+import { logger } from "cli/logging";
 import { loginCommand } from "cli/login";
 import { logoutCommand } from "cli/logout";
 import { whoamiCommand } from "cli/whoami";
@@ -11,8 +13,36 @@ const program = new Command()
   .name("sindri")
   .description("The Sindri CLI client.")
   .version(process.env.npm_package_version ?? "0.0.0")
+  .option("-d, --debug", "Enable debug logging.", false)
+  .option(
+    "-q, --quiet",
+    "Disable all logging aside from direct command outputs for programmatic consumption.",
+    false,
+  )
   .addCommand(loginCommand)
   .addCommand(logoutCommand)
-  .addCommand(whoamiCommand);
+  .addCommand(whoamiCommand)
+  // Parse the base command options and respond to them before invoking the subcommand.
+  .hook("preAction", async (command) => {
+    // Set the logging level.
+    const { debug, quiet } = command.opts();
+    if (debug && quiet) {
+      logger.error(
+        "You cannot specify both the `--debug` and `--quiet` arguments.",
+      );
+      return exit(1);
+    }
+    if (debug) {
+      logger.level = "trace";
+    } else if (quiet) {
+      logger.level = "silent";
+    } else {
+      logger.level = "info";
+    }
+    logger.debug(`Set log level to "${logger.level}".`);
+
+    // Force the loading of the config before subcommands.
+    new Config();
+  });
 
 program.parse(argv);

--- a/src/cli/logging.ts
+++ b/src/cli/logging.ts
@@ -1,21 +1,14 @@
-import process from "process";
-
 import pino from "pino";
+import pretty from "pino-pretty";
 
-export const logger = pino(
-  {
-    transport: {
-      options: {
-        // Write all logs to stderr.
-        destination: 2,
-        // Write synchronously so logs appear before inquirer prompts.
-        sync: true,
-      },
-      // Pretty print instead of JSON logging.
-      target: "pino-pretty",
-    },
-  },
-  process.stdout,
-);
+const prettyStream = pretty({
+  colorize: true,
+  destination: 2,
+  ignore: "hostname,pid",
+  levelFirst: false,
+  sync: true,
+});
+
+export const logger = pino(prettyStream);
 
 export const print = console.log;

--- a/src/cli/logging.ts
+++ b/src/cli/logging.ts
@@ -1,0 +1,21 @@
+import process from "process";
+
+import pino from "pino";
+
+export const logger = pino(
+  {
+    transport: {
+      options: {
+        // Write all logs to stderr.
+        destination: 2,
+        // Write synchronously so logs appear before inquirer prompts.
+        sync: true,
+      },
+      // Pretty print instead of JSON logging.
+      target: "pino-pretty",
+    },
+  },
+  process.stdout,
+);
+
+export const print = console.log;

--- a/src/cli/login.ts
+++ b/src/cli/login.ts
@@ -1,6 +1,6 @@
 import os from "os";
+import process from "process";
 
-import chalk from "chalk";
 import { Command } from "@commander-js/extra-typings";
 import {
   confirm,
@@ -9,7 +9,8 @@ import {
   select,
 } from "@inquirer/prompts";
 
-import { config } from "cli/config";
+import { Config } from "cli/config";
+import { logger } from "cli/logging";
 import {
   AuthorizationService,
   InternalService,
@@ -26,6 +27,7 @@ export const loginCommand = new Command()
     OpenAPI.BASE,
   )
   .action(async ({ baseUrl }) => {
+    const config = new Config();
     const auth = config.auth;
     if (auth) {
       const proceed = await confirm({
@@ -35,7 +37,7 @@ export const loginCommand = new Command()
         default: false,
       });
       if (!proceed) {
-        console.log("Aborting.");
+        logger.info("Aborting.");
         return;
       }
     }
@@ -84,13 +86,12 @@ export const loginCommand = new Command()
 
       // Store the new auth information.
       config.update({ auth: { apiKey, baseUrl, teamId, teamSlug: team.slug } });
-      console.log(
-        chalk.green(
-          "You have successfully authorized the client with your Sindri account.",
-        ),
+      logger.info(
+        "You have successfully authorized the client with your Sindri account.",
       );
     } catch (error) {
-      console.error(chalk.red("Something went wrong."));
-      console.error(error);
+      logger.fatal("An irrecoverable error occurred.");
+      logger.error(error);
+      process.exit(1);
     }
   });

--- a/src/cli/login.ts
+++ b/src/cli/login.ts
@@ -1,17 +1,26 @@
 import os from "os";
 
-import axios from "axios";
 import chalk from "chalk";
 import { Command } from "@commander-js/extra-typings";
 import { input, password as passwordInput, select } from "@inquirer/prompts";
 
 import { config } from "cli/config";
-import { AuthorizationService, InternalService, TokenService } from "lib/api";
+import {
+  AuthorizationService,
+  InternalService,
+  OpenAPI,
+  TokenService,
+} from "lib/api";
 
 export const loginCommand = new Command()
   .name("login")
   .description("Authorize the client.")
-  .action(async () => {
+  .option(
+    "-u, --base-url <URL>",
+    "The base URL for the Sindri API. Mainly useful for development.",
+    OpenAPI.BASE,
+  )
+  .action(async ({ baseUrl }) => {
     // Collect details for generating an API key.
     const username = await input({ message: "Username:" });
     const password = await passwordInput({ mask: true, message: "Password:" });
@@ -23,13 +32,12 @@ export const loginCommand = new Command()
     // Generate an API key for one of their teams.
     try {
       // Generate a JWT token to authenticate the user.
+      OpenAPI.BASE = baseUrl;
       const tokenResult = await TokenService.bf740E1AControllerObtainToken({
         username,
         password,
       });
-      axios.defaults.headers.common = {
-        Authorization: `Bearer ${tokenResult.access}`,
-      };
+      OpenAPI.TOKEN = tokenResult.access;
 
       // Fetch their teams and have the user select one.
       const userResult = await InternalService.userMeWithJwtAuth();
@@ -57,7 +65,7 @@ export const loginCommand = new Command()
       }
 
       // Store the new auth information.
-      config.update({ auth: { apiKey, teamId, teamSlug: team.slug } });
+      config.update({ auth: { apiKey, baseUrl, teamId, teamSlug: team.slug } });
       console.log(
         chalk.green(
           "You have successfully authorized the client with your Sindri account.",

--- a/src/cli/login.ts
+++ b/src/cli/login.ts
@@ -26,7 +26,7 @@ export const loginCommand = new Command()
     const password = await passwordInput({ mask: true, message: "Password:" });
     const name = await input({
       default: `${os.hostname()}-sdk`,
-      message: "Key Name:",
+      message: "New API Key Name:",
     });
 
     // Generate an API key for one of their teams.

--- a/src/cli/login.ts
+++ b/src/cli/login.ts
@@ -2,7 +2,12 @@ import os from "os";
 
 import chalk from "chalk";
 import { Command } from "@commander-js/extra-typings";
-import { input, password as passwordInput, select } from "@inquirer/prompts";
+import {
+  confirm,
+  input,
+  password as passwordInput,
+  select,
+} from "@inquirer/prompts";
 
 import { config } from "cli/config";
 import {
@@ -21,6 +26,19 @@ export const loginCommand = new Command()
     OpenAPI.BASE,
   )
   .action(async ({ baseUrl }) => {
+    const auth = config.auth;
+    if (auth) {
+      const proceed = await confirm({
+        message:
+          `You are already logged in as ${auth.teamSlug} on ${auth.baseUrl}, ` +
+          "are you sure you want to proceed?",
+        default: false,
+      });
+      if (!proceed) {
+        console.log("Aborting.");
+        return;
+      }
+    }
     // Collect details for generating an API key.
     const username = await input({ message: "Username:" });
     const password = await passwordInput({ mask: true, message: "Password:" });

--- a/src/cli/logout.ts
+++ b/src/cli/logout.ts
@@ -5,7 +5,7 @@ import { config } from "cli/config";
 
 export const logoutCommand = new Command()
   .name("logout")
-  .description("Display the currently authorized team name.")
+  .description("Remove the current client authorization credentials.")
   .action(async () => {
     // Authorize the API client.
     const auth = config.auth;

--- a/src/cli/logout.ts
+++ b/src/cli/logout.ts
@@ -1,19 +1,20 @@
-import chalk from "chalk";
 import { Command } from "@commander-js/extra-typings";
 
-import { config } from "cli/config";
+import { Config } from "cli/config";
+import { logger } from "cli/logging";
 
 export const logoutCommand = new Command()
   .name("logout")
   .description("Remove the current client authorization credentials.")
   .action(async () => {
     // Authorize the API client.
+    const config = new Config();
     const auth = config.auth;
     if (!auth) {
-      console.error(chalk.red("You must log in first with `sindri login`."));
+      logger.error("You must log in first with `sindri login`.");
       return;
     }
 
     config.update({ auth: null });
-    console.log(chalk.green("You have successfully logged out."));
+    logger.info("You have successfully logged out.");
   });

--- a/src/cli/whoami.ts
+++ b/src/cli/whoami.ts
@@ -1,21 +1,24 @@
-import chalk from "chalk";
+import process from "process";
+
 import { Command } from "@commander-js/extra-typings";
 
-import { config } from "cli/config";
+import { Config } from "cli/config";
+import { logger, print } from "cli/logging";
 
 export const whoamiCommand = new Command()
   .name("whoami")
   .description("Display the currently authorized team name.")
   .action(async () => {
     // Authorize the API client.
+    const config = new Config();
     const auth = config.auth;
     if (!auth) {
-      console.error(chalk.red("You must login first with `sindri login`."));
-      return;
+      logger.warn("You must login first with `sindri login`.");
+      return process.exit(1);
     }
 
     // TODO: Use the new "team-me" endpoint to test authentication and fetch the current team.
     // This should be deployed soon, and we'll update this method then. For now, we just rely on
     // whatever the team slug was when we logged in last.
-    console.log(auth.teamSlug);
+    print(auth.teamSlug);
   });

--- a/src/cli/whoami.ts
+++ b/src/cli/whoami.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import chalk from "chalk";
 import { Command } from "@commander-js/extra-typings";
 
@@ -14,9 +13,6 @@ export const whoamiCommand = new Command()
       console.error(chalk.red("You must login first with `sindri login`."));
       return;
     }
-    axios.defaults.headers.common = {
-      Authorization: `Bearer ${auth.apiKey}`,
-    };
 
     // TODO: Use the new "team-me" endpoint to test authentication and fetch the current team.
     // This should be deployed soon, and we'll update this method then. For now, we just rely on

--- a/yarn.lock
+++ b/yarn.lock
@@ -561,6 +561,13 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
+abort-controller@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
+  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
+  dependencies:
+    event-target-shim "^5.0.0"
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
@@ -628,6 +635,11 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
+atomic-sleep@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/atomic-sleep/-/atomic-sleep-1.0.0.tgz#eb85b77a601fc932cfe432c5acd364a9e2c9075b"
+  integrity sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==
+
 axios@^1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.2.tgz#de67d42c755b571d3e698df1b6504cde9b0ee9f2"
@@ -641,6 +653,11 @@ balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
+base64-js@^1.3.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
 big-integer@^1.6.44:
   version "1.6.51"
@@ -667,12 +684,27 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
+brace-expansion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
+  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  dependencies:
+    balanced-match "^1.0.0"
+
 braces@^3.0.2, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+buffer@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
 
 bundle-name@^3.0.0:
   version "3.0.0"
@@ -758,6 +790,11 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+colorette@^2.0.7:
+  version "2.0.20"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
+  integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
+
 combined-stream@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
@@ -788,6 +825,11 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+dateformat@^4.6.3:
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-4.6.3.tgz#556fa6497e5217fedb78821424f8a1c22fa3f4b5"
+  integrity sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==
 
 debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
@@ -852,6 +894,13 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+end-of-stream@^1.1.0:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
+  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
+  dependencies:
+    once "^1.4.0"
 
 env-paths@^2.2.1:
   version "2.2.1"
@@ -999,6 +1048,16 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
+event-target-shim@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
+  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
+
+events@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
+  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
+
 execa@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
@@ -1038,6 +1097,11 @@ external-editor@^3.1.0:
     iconv-lite "^0.4.24"
     tmp "^0.0.33"
 
+fast-copy@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-3.0.1.tgz#9e89ef498b8c04c1cd76b33b8e14271658a732aa"
+  integrity sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA==
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -1068,6 +1132,16 @@ fast-levenshtein@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
+
+fast-redact@^3.1.1:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/fast-redact/-/fast-redact-3.3.0.tgz#7c83ce3a7be4898241a46560d51de10f653f7634"
+  integrity sha512-6T5V1QK1u4oF+ATxs1lWUmlEk6P2T9HqJG3e2DnHOdVgZy2rFJBoEnrIedcTXlkAHU/zKC+7KETJ+KGGKwxgMQ==
+
+fast-safe-stringify@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
+  integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
 
 fastq@^1.6.0:
   version "1.15.0"
@@ -1195,6 +1269,17 @@ glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+glob@^8.0.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
+  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^5.0.1"
+    once "^1.3.0"
+
 globals@^13.19.0:
   version "13.23.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-13.23.0.tgz#ef31673c926a0976e1f61dab4dca57e0c0a8af02"
@@ -1241,6 +1326,14 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
+help-me@^4.0.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/help-me/-/help-me-4.2.0.tgz#50712bfd799ff1854ae1d312c36eafcea85b0563"
+  integrity sha512-TAOnTB8Tz5Dw8penUuzHVrKNKlCIbwwbHnXraNJxPwf8LRtE2HlM84RYuezMFcwOJmoYOCWVDyJ8TQGxn9PgxA==
+  dependencies:
+    glob "^8.0.0"
+    readable-stream "^3.6.0"
+
 human-signals@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
@@ -1257,6 +1350,11 @@ iconv-lite@^0.4.24:
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+ieee754@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 ignore@^5.2.0, ignore@^5.2.4:
   version "5.3.0"
@@ -1284,7 +1382,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2:
+inherits@2, inherits@^2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -1367,7 +1465,7 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
-joycon@^3.0.1:
+joycon@^3.0.1, joycon@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/joycon/-/joycon-3.1.1.tgz#bce8596d6ae808f8b68168f5fc69280996894f03"
   integrity sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==
@@ -1516,7 +1614,14 @@ minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.0, minimist@^1.2.5:
+minimatch@^5.0.1:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
+  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
+  dependencies:
+    brace-expansion "^2.0.1"
+
+minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
@@ -1574,7 +1679,12 @@ object-assign@^4.0.1:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
 
-once@^1.3.0:
+on-exit-leak-free@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz#fed195c9ebddb7d9e4c3842f93f281ac8dadd3b8"
+  integrity sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==
+
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
@@ -1689,6 +1799,56 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
+pino-abstract-transport@^1.0.0, pino-abstract-transport@v1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pino-abstract-transport/-/pino-abstract-transport-1.1.0.tgz#083d98f966262164504afb989bccd05f665937a8"
+  integrity sha512-lsleG3/2a/JIWUtf9Q5gUNErBqwIu1tUKTT3dUzaf5DySw9ra1wcqKjJjLX1VTY64Wk1eEOYsVGSaGfCK85ekA==
+  dependencies:
+    readable-stream "^4.0.0"
+    split2 "^4.0.0"
+
+pino-pretty@^10.2.3:
+  version "10.2.3"
+  resolved "https://registry.yarnpkg.com/pino-pretty/-/pino-pretty-10.2.3.tgz#db539c796a1421fd4d130734fa994f5a26027783"
+  integrity sha512-4jfIUc8TC1GPUfDyMSlW1STeORqkoxec71yhxIpLDQapUu8WOuoz2TTCoidrIssyz78LZC69whBMPIKCMbi3cw==
+  dependencies:
+    colorette "^2.0.7"
+    dateformat "^4.6.3"
+    fast-copy "^3.0.0"
+    fast-safe-stringify "^2.1.1"
+    help-me "^4.0.1"
+    joycon "^3.1.1"
+    minimist "^1.2.6"
+    on-exit-leak-free "^2.1.0"
+    pino-abstract-transport "^1.0.0"
+    pump "^3.0.0"
+    readable-stream "^4.0.0"
+    secure-json-parse "^2.4.0"
+    sonic-boom "^3.0.0"
+    strip-json-comments "^3.1.1"
+
+pino-std-serializers@^6.0.0:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-6.2.2.tgz#d9a9b5f2b9a402486a5fc4db0a737570a860aab3"
+  integrity sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==
+
+pino@^8.16.2:
+  version "8.16.2"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-8.16.2.tgz#7a906f2d9a8c5b4c57412c9ca95d6820bd2090cd"
+  integrity sha512-2advCDGVEvkKu9TTVSa/kWW7Z3htI/sBKEZpqiHk6ive0i/7f5b1rsU8jn0aimxqfnSz5bj/nOYkwhBUn5xxvg==
+  dependencies:
+    atomic-sleep "^1.0.0"
+    fast-redact "^3.1.1"
+    on-exit-leak-free "^2.1.0"
+    pino-abstract-transport v1.1.0
+    pino-std-serializers "^6.0.0"
+    process-warning "^2.0.0"
+    quick-format-unescaped "^4.0.3"
+    real-require "^0.2.0"
+    safe-stable-stringify "^2.3.1"
+    sonic-boom "^3.7.0"
+    thread-stream "^2.0.0"
+
 pirates@^4.0.1:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.6.tgz#3018ae32ecfcff6c29ba2267cbf21166ac1f36b9"
@@ -1719,10 +1879,28 @@ prettier@^3.1.0:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.1.0.tgz#c6d16474a5f764ea1a4a373c593b779697744d5e"
   integrity sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==
 
+process-warning@^2.0.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/process-warning/-/process-warning-2.3.1.tgz#0caf992272c439f45dd416e1407ee25a3d4c778a"
+  integrity sha512-JjBvFEn7MwFbzUDa2SRtKJSsyO0LlER4V/FmwLMhBlXNbGgGxdyFCxIdMDLerWUycsVUyaoM9QFLvppFy4IWaQ==
+
+process@^0.11.10:
+  version "0.11.10"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
+  integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
+
 proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
+pump@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
+  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
 
 punycode@^2.1.0:
   version "2.3.1"
@@ -1734,6 +1912,11 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
+quick-format-unescaped@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz#93ef6dd8d3453cbc7970dd614fad4c5954d6b5a7"
+  integrity sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==
+
 rc@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
@@ -1744,12 +1927,37 @@ rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+readable-stream@^3.6.0:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
+  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
+readable-stream@^4.0.0:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-4.4.2.tgz#e6aced27ad3b9d726d8308515b9a1b98dc1b9d13"
+  integrity sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==
+  dependencies:
+    abort-controller "^3.0.0"
+    buffer "^6.0.3"
+    events "^3.3.0"
+    process "^0.11.10"
+    string_decoder "^1.3.0"
+
 readdirp@~3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
+
+real-require@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/real-require/-/real-require-0.2.0.tgz#209632dea1810be2ae063a6ac084fee7e33fba78"
+  integrity sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==
 
 resolve-from@^4.0.0:
   version "4.0.0"
@@ -1811,10 +2019,25 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
+safe-buffer@~5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+safe-stable-stringify@^2.3.1:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz#138c84b6f6edb3db5f8ef3ef7115b8f55ccbf886"
+  integrity sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==
+
 "safer-buffer@>= 2.1.2 < 3":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+secure-json-parse@^2.4.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/secure-json-parse/-/secure-json-parse-2.7.0.tgz#5a5f9cd6ae47df23dba3151edd06855d47e09862"
+  integrity sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==
 
 semver@^7.5.4:
   version "7.5.4"
@@ -1850,6 +2073,13 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
+sonic-boom@^3.0.0, sonic-boom@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/sonic-boom/-/sonic-boom-3.7.0.tgz#b4b7b8049a912986f4a92c51d4660b721b11f2f2"
+  integrity sha512-IudtNvSqA/ObjN97tfgNmOKyDOs4dNcg4cUUsHDebqsgb8wGBBwb31LIgShNO8fye0dFI52X1+tFoKKI6Rq1Gg==
+  dependencies:
+    atomic-sleep "^1.0.0"
+
 source-map@0.8.0-beta.0:
   version "0.8.0-beta.0"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.8.0-beta.0.tgz#d4c1bb42c3f7ee925f005927ba10709e0d1d1f11"
@@ -1862,6 +2092,11 @@ source-map@^0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
+split2@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/split2/-/split2-4.2.0.tgz#c9c5920904d148bab0b9f67145f245a86aadbfa4"
+  integrity sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==
+
 string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
@@ -1870,6 +2105,13 @@ string-width@^4.1.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
+
+string_decoder@^1.1.1, string_decoder@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
 
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
@@ -1944,6 +2186,13 @@ thenify-all@^1.0.0:
   integrity sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==
   dependencies:
     any-promise "^1.0.0"
+
+thread-stream@^2.0.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/thread-stream/-/thread-stream-2.4.1.tgz#6d588b14f0546e59d3f306614f044bc01ce43351"
+  integrity sha512-d/Ex2iWd1whipbT681JmTINKw0ZwOUBZm7+Gjs64DHuX34mmw8vJL2bFAaNacaW72zYiTJxSHi5abUuOi5nsfg==
+  dependencies:
+    real-require "^0.2.0"
 
 titleize@^3.0.0:
   version "3.0.0"
@@ -2059,6 +2308,11 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+util-deprecate@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
 webidl-conversions@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
This cleans up the auth commands a little bit, integrates `pino` for logging, and adds a `--baseUrl` argument to `sindri login` which can be used for working against a local development or staging environment.
