### PR TITLE
Export the CLI program from the module

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9,7 +9,7 @@ import { loginCommand } from "cli/login";
 import { logoutCommand } from "cli/logout";
 import { whoamiCommand } from "cli/whoami";
 
-const program = new Command()
+export const program = new Command()
   .name("sindri")
   .description("The Sindri CLI client.")
   .version(process.env.npm_package_version ?? "0.0.0")

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -46,4 +46,6 @@ export const program = new Command()
     new Config();
   });
 
-program.parse(argv);
+if (require.main === module) {
+  program.parse(argv);
+}


### PR DESCRIPTION
This exports the commander.js program object from the CLI module, and only executes the program when `require.main === module`. This allows us to use the program object during documentation builds.
