### PR TITLE
Fix how the CLI version is determined

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "openapi-typescript-codegen": "^0.25.0",
     "prettier": "^3.1.0",
     "tsup": "^7.3.0",
+    "type-fest": "^4.8.2",
     "typescript": "^5.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "./cli": "./dist/cli/index.js"
   },
   "scripts": {
-    "build": "NODE_ENV=production tsup --env.NODE_ENV $NODE_ENV --env.npm_package_version $npm_package_version",
-    "build:watch": "NODE_ENV=development tsup --watch --env.NODE_ENV $NODE_ENV --env.npm_package_version $npm_package_version",
+    "build": "NODE_ENV=production tsup --env.NODE_ENV $NODE_ENV",
+    "build:watch": "NODE_ENV=development tsup --watch --env.NODE_ENV $NODE_ENV",
     "generate-api": "rm -rf src/lib/api/ && openapi --client axios --input https://forge.sindri.app/api/openapi.json --output src/lib/api/ && prettier --write src/lib/api/**/*",
     "generate-api:dev": "rm -rf src/lib/api/ && openapi --client axios --input http://localhost/api/openapi.json --output src/lib/api/ && prettier --write src/lib/api/**/*",
     "generate-api:docker": "rm -rf src/lib/api/ && openapi --client axios --input http://host.docker.internal/api/openapi.json --output src/lib/api/ && prettier --write src/lib/api/**/*",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,11 +8,12 @@ import { logger } from "cli/logging";
 import { loginCommand } from "cli/login";
 import { logoutCommand } from "cli/logout";
 import { whoamiCommand } from "cli/whoami";
+import { loadPackageJson } from "cli/utils";
 
 export const program = new Command()
   .name("sindri")
   .description("The Sindri CLI client.")
-  .version(process.env.npm_package_version ?? "0.0.0")
+  .version(loadPackageJson().version ?? "unknown")
   .option("-d, --debug", "Enable debug logging.", false)
   .option(
     "-q, --quiet",

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -1,0 +1,68 @@
+import { readdirSync, readFileSync } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+import type { PackageJson } from "type-fest";
+
+const currentFilePath = fileURLToPath(import.meta.url);
+const currentDirectoryPath = path.dirname(currentFilePath);
+
+/**
+ * Recursively searches for a file in the given directory and its parent directories.
+ *
+ * @param filename - The name or regular expression of the file to find.
+ * @param initialDirectory - The directory to start the search in.
+ * @returns The fully qualified path of the first file found, or `null` if none is found.
+ */
+export function findFileUpwards(
+  filename: string | RegExp,
+  initialDirectory: string = currentDirectoryPath,
+): string | null {
+  // List files in the current directory.
+  const files = readdirSync(initialDirectory);
+
+  // Check if any file matches the filename.
+  for (const file of files) {
+    if (
+      typeof filename === "string" ? file === filename : filename.test(file)
+    ) {
+      return path.join(initialDirectory, file);
+    }
+  }
+
+  // If the parent directory is the same as the current, we've reached the root.
+  const parentDirectory = path.dirname(initialDirectory);
+  if (parentDirectory === initialDirectory) {
+    return null;
+  }
+
+  // Recursively search in the parent directory.
+  return findFileUpwards(filename, parentDirectory);
+}
+
+/**
+ * Loads the project's `package.json` file.
+ *
+ * @returns The contents of `package.json`.
+ */
+export function loadPackageJson(): PackageJson {
+  const packageJsonPath = locatePackageJson();
+  const packageJsonContent = readFileSync(packageJsonPath, {
+    encoding: "utf-8",
+  });
+  const packageJson: PackageJson = JSON.parse(packageJsonContent);
+  return packageJson;
+}
+
+/**
+ * Locates the project's `package.json` file.
+ *
+ * @returns The fully qualified path to `package.json`.
+ */
+export function locatePackageJson(): string {
+  const packageJsonPath = findFileUpwards("package.json");
+  if (!packageJsonPath) {
+    throw new Error("A `package.json` file was unexpectedly not found.");
+  }
+  return packageJsonPath;
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -9,6 +9,7 @@ export default defineConfig([
     format: ["cjs", "esm"],
     minify: process.env.NODE_ENV === "production",
     outDir: "dist/lib",
+    shims: true,
     sourcemap: true,
     // CJS interop is broken without splitting, see:
     //   * https://github.com/egoist/tsup/issues/992#issuecomment-1763540165
@@ -22,6 +23,7 @@ export default defineConfig([
     format: ["cjs", "esm"],
     minify: process.env.NODE_ENV === "production",
     outDir: "dist/lib/browser",
+    shims: true,
     sourcemap: true,
     splitting: true,
     target: "esnext",
@@ -35,6 +37,7 @@ export default defineConfig([
     format: ["cjs"],
     minify: process.env.NODE_ENV === "production",
     outDir: "dist/cli",
+    shims: true,
     sourcemap: true,
     target: "node18",
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2277,6 +2277,11 @@ type-fest@^0.21.3:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
+type-fest@^4.8.2:
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.8.2.tgz#20d4cc287745723dbabf925de644eeb7de0349c1"
+  integrity sha512-mcvrCjixA5166hSrUoJgGb9gBQN4loMYyj9zxuMs/66ibHNEFd5JXMw37YVDx58L4/QID9jIzdTBB4mDwDJ6KQ==
+
 typescript@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"


### PR DESCRIPTION
We were trying to pass this in with an `npm_package_version` environment variable before, but it wasn't reliable. This adds some utilities for finding/loading the project's `package.json` file directly and pulls the version out of that. These utilities will also be useful for other things like determining the location of the scaffolding templates and finding local config files.
