### PR TITLE
Add a `lint` command and integrate the Sindri Manifest JSON Schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,27 @@ yarn generate-api:dev
 yarn denerate-api:docker
 ```
 
+### Updating Sindri Manifest JSON Schema
+
+The Sindri Manifest JSON Schema is stored in [`sindri-manifest.json`](sindri-manifest.json) and needs to be manually updated and committed when the schema changes.
+The file can be updated by running:
+
+```bash
+yarn download-sindri-manifest-schema
+```
+
+To develop against an unreleased version of the schema, you can use these variants to target a local development server:
+
+```bash
+# If you're not using Docker:
+yarn download-sindri-manifest-schema:dev
+
+# Or...
+
+# If you are using Docker:
+yarn download-sindri-manifest-schema:docker
+```
+
 ### Linting
 
 To lint the project with Eslint and Prettier:

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "commander": "^11.1.0",
     "env-paths": "^2.2.1",
     "form-data": "^4.0.0",
+    "jsonschema": "^1.4.1",
     "lodash": "^4.17.21",
     "pino": "^8.16.2",
     "pino-pretty": "^10.2.3",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   "scripts": {
     "build": "NODE_ENV=production tsup --env.NODE_ENV $NODE_ENV",
     "build:watch": "NODE_ENV=development tsup --watch --env.NODE_ENV $NODE_ENV",
-    "download-sindri-manifest-schema": "nwget https://forge.sindri.app/api/v1/sindri-manifest-schema.json -O sindri-manifest.json",
-    "download-sindri-manifest-schema:dev": "nwget http://localhost/api/v1/sindri-manifest-schema.json -O sindri-manifest.json",
-    "download-sindri-manifest-schema:docker": "nwget http://host.docker.internal/api/v1/sindri-manifest-schema.json -O sindri-manifest.json",
+    "download-sindri-manifest-schema": "nwget https://forge.sindri.app/api/v1/sindri-manifest-schema.json -O sindri-manifest.json && prettier --write sindri-manifest.json",
+    "download-sindri-manifest-schema:dev": "nwget http://localhost/api/v1/sindri-manifest-schema.json -O sindri-manifest.json && prettier --write sindri-manifest.json",
+    "download-sindri-manifest-schema:docker": "nwget http://host.docker.internal/api/v1/sindri-manifest-schema.json -O sindri-manifest.json && prettier --write sindri-manifest.json",
     "generate-api": "rm -rf src/lib/api/ && openapi --client axios --input https://forge.sindri.app/api/openapi.json --output src/lib/api/ && prettier --write src/lib/api/**/*",
     "generate-api:dev": "rm -rf src/lib/api/ && openapi --client axios --input http://localhost/api/openapi.json --output src/lib/api/ && prettier --write src/lib/api/**/*",
     "generate-api:docker": "rm -rf src/lib/api/ && openapi --client axios --input http://host.docker.internal/api/openapi.json --output src/lib/api/ && prettier --write src/lib/api/**/*",

--- a/package.json
+++ b/package.json
@@ -2,10 +2,7 @@
   "name": "sindri",
   "version": "0.0.0",
   "description": "The Sindri Labs JavaScript SDK and CLI tool.",
-  "files": [
-    "dist/",
-    "src/"
-  ],
+  "files": ["dist/", "src/"],
   "main": "dist/lib/index.js",
   "module": "dist/lib/index.mjs",
   "bin": {
@@ -25,6 +22,9 @@
   "scripts": {
     "build": "NODE_ENV=production tsup --env.NODE_ENV $NODE_ENV",
     "build:watch": "NODE_ENV=development tsup --watch --env.NODE_ENV $NODE_ENV",
+    "download-sindri-manifest-schema": "nwget https://forge.sindri.app/api/v1/sindri-manifest-schema.json -O sindri-manifest.json",
+    "download-sindri-manifest-schema:dev": "nwget http://localhost/api/v1/sindri-manifest-schema.json -O sindri-manifest.json",
+    "download-sindri-manifest-schema:docker": "nwget http://host.docker.internal/api/v1/sindri-manifest-schema.json -O sindri-manifest.json",
     "generate-api": "rm -rf src/lib/api/ && openapi --client axios --input https://forge.sindri.app/api/openapi.json --output src/lib/api/ && prettier --write src/lib/api/**/*",
     "generate-api:dev": "rm -rf src/lib/api/ && openapi --client axios --input http://localhost/api/openapi.json --output src/lib/api/ && prettier --write src/lib/api/**/*",
     "generate-api:docker": "rm -rf src/lib/api/ && openapi --client axios --input http://host.docker.internal/api/openapi.json --output src/lib/api/ && prettier --write src/lib/api/**/*",
@@ -69,6 +69,7 @@
     "prettier": "^3.1.0",
     "tsup": "^7.3.0",
     "type-fest": "^4.8.2",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "wget-improved": "^3.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sindri",
   "version": "0.0.0",
   "description": "The Sindri Labs JavaScript SDK and CLI tool.",
-  "files": ["dist/", "src/"],
+  "files": ["dist/", "src/", "sindri-manifest.json"],
   "main": "dist/lib/index.js",
   "module": "dist/lib/index.mjs",
   "bin": {

--- a/sindri-manifest.json
+++ b/sindri-manifest.json
@@ -100,7 +100,8 @@
       "required": [
         "circuitType",
         "name"
-      ]
+      ],
+      "additionalProperties": false
     },
     "GnarkCurveOptions": {
       "title": "GnarkCurveOptions",
@@ -178,7 +179,8 @@
         "circuitStructName",
         "gnarkVersion",
         "packageName"
-      ]
+      ],
+      "additionalProperties": false
     },
     "Halo2VersionOptions": {
       "title": "Halo2VersionOptions",
@@ -225,7 +227,8 @@
         "degree",
         "halo2Version",
         "packageName"
-      ]
+      ],
+      "additionalProperties": false
     },
     "Halo2AxiomV030Sindri": {
       "title": "Halo2AxiomV030Sindri",
@@ -271,7 +274,8 @@
         "halo2Version",
         "packageName",
         "threadBuilder"
-      ]
+      ],
+      "additionalProperties": false
     },
     "Halo2ChiquitoSindri": {
       "title": "Halo2ChiquitoSindri",
@@ -308,7 +312,8 @@
         "degree",
         "halo2Version",
         "packageName"
-      ]
+      ],
+      "additionalProperties": false
     },
     "NoirProvingSchemeOptions": {
       "title": "NoirProvingSchemeOptions",
@@ -342,7 +347,8 @@
       "required": [
         "circuitType",
         "name"
-      ]
+      ],
+      "additionalProperties": false
     }
   }
 }

--- a/sindri-manifest.json
+++ b/sindri-manifest.json
@@ -1,5 +1,5 @@
 {
-  "$id": "http://localhost/api/v1/sindri-manifest-schema.json",
+  "$id": "https://forge.sindri.app/api/v1/sindri-manifest-schema.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "SindriManifest",
   "description": "Discriminated union type for `sindri.json` manifest files.\n\nThis is only used for serializing the JSON Schema currently, but it would be nice to use it more\nbroadly once we improve the typing on the union types. We should be able to use\n`SindriManifest.parse_obj()` instead of `get_validate_sindri_manifest()` and other\nsimplifications.",
@@ -27,37 +27,25 @@
     "SindriCircuitTypeOptions": {
       "title": "SindriCircuitTypeOptions",
       "description": "circuit_type options",
-      "enum": [
-        "circom",
-        "gnark",
-        "halo2",
-        "noir"
-      ],
+      "enum": ["circom", "gnark", "halo2", "noir"],
       "type": "string"
     },
     "CircomCurveOptions": {
       "title": "CircomCurveOptions",
       "description": "An enumeration.",
-      "enum": [
-        "bn254"
-      ],
+      "enum": ["bn254"],
       "type": "string"
     },
     "CircomProvingSchemeOptions": {
       "title": "CircomProvingSchemeOptions",
       "description": "An enumeration.",
-      "enum": [
-        "groth16"
-      ],
+      "enum": ["groth16"],
       "type": "string"
     },
     "CircomWitnessCompilerOptions": {
       "title": "CircomWitnessCompilerOptions",
       "description": "An enumeration.",
-      "enum": [
-        "c++",
-        "wasm"
-      ],
+      "enum": ["c++", "wasm"],
       "type": "string"
     },
     "CircomSindri": {
@@ -97,10 +85,7 @@
           ]
         }
       },
-      "required": [
-        "circuitType",
-        "name"
-      ],
+      "required": ["circuitType", "name"],
       "additionalProperties": false
     },
     "GnarkCurveOptions": {
@@ -119,18 +104,13 @@
     "GnarkVersionOptions": {
       "title": "GnarkVersionOptions",
       "description": "An enumeration.",
-      "enum": [
-        "v0.8.1",
-        "v0.9.0"
-      ],
+      "enum": ["v0.8.1", "v0.9.0"],
       "type": "string"
     },
     "GnarkProvingSchemeOptions": {
       "title": "GnarkProvingSchemeOptions",
       "description": "An enumeration.",
-      "enum": [
-        "groth16"
-      ],
+      "enum": ["groth16"],
       "type": "string"
     },
     "GnarkSindri": {
@@ -185,11 +165,7 @@
     "Halo2VersionOptions": {
       "title": "Halo2VersionOptions",
       "description": "An enumeration.",
-      "enum": [
-        "axiom-v0.2.2",
-        "axiom-v0.3.0",
-        "chiquito"
-      ],
+      "enum": ["axiom-v0.2.2", "axiom-v0.3.0", "chiquito"],
       "type": "string"
     },
     "Halo2AxiomV022Sindri": {
@@ -259,10 +235,7 @@
         },
         "threadBuilder": {
           "title": "Thread Builder",
-          "enum": [
-            "GateThreadBuilder",
-            "RlcThreadBuilder"
-          ],
+          "enum": ["GateThreadBuilder", "RlcThreadBuilder"],
           "type": "string"
         }
       },
@@ -318,9 +291,7 @@
     "NoirProvingSchemeOptions": {
       "title": "NoirProvingSchemeOptions",
       "description": "An enumeration.",
-      "enum": [
-        "barretenberg"
-      ],
+      "enum": ["barretenberg"],
       "type": "string"
     },
     "NoirSindri": {
@@ -344,10 +315,7 @@
           ]
         }
       },
-      "required": [
-        "circuitType",
-        "name"
-      ],
+      "required": ["circuitType", "name"],
       "additionalProperties": false
     }
   }

--- a/sindri-manifest.json
+++ b/sindri-manifest.json
@@ -1,0 +1,348 @@
+{
+  "$id": "http://localhost/api/v1/sindri-manifest-schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "SindriManifest",
+  "description": "Discriminated union type for `sindri.json` manifest files.\n\nThis is only used for serializing the JSON Schema currently, but it would be nice to use it more\nbroadly once we improve the typing on the union types. We should be able to use\n`SindriManifest.parse_obj()` instead of `get_validate_sindri_manifest()` and other\nsimplifications.",
+  "anyOf": [
+    {
+      "$ref": "#/definitions/CircomSindri"
+    },
+    {
+      "$ref": "#/definitions/GnarkSindri"
+    },
+    {
+      "$ref": "#/definitions/Halo2AxiomV022Sindri"
+    },
+    {
+      "$ref": "#/definitions/Halo2AxiomV030Sindri"
+    },
+    {
+      "$ref": "#/definitions/Halo2ChiquitoSindri"
+    },
+    {
+      "$ref": "#/definitions/NoirSindri"
+    }
+  ],
+  "definitions": {
+    "SindriCircuitTypeOptions": {
+      "title": "SindriCircuitTypeOptions",
+      "description": "circuit_type options",
+      "enum": [
+        "circom",
+        "gnark",
+        "halo2",
+        "noir"
+      ],
+      "type": "string"
+    },
+    "CircomCurveOptions": {
+      "title": "CircomCurveOptions",
+      "description": "An enumeration.",
+      "enum": [
+        "bn254"
+      ],
+      "type": "string"
+    },
+    "CircomProvingSchemeOptions": {
+      "title": "CircomProvingSchemeOptions",
+      "description": "An enumeration.",
+      "enum": [
+        "groth16"
+      ],
+      "type": "string"
+    },
+    "CircomWitnessCompilerOptions": {
+      "title": "CircomWitnessCompilerOptions",
+      "description": "An enumeration.",
+      "enum": [
+        "c++",
+        "wasm"
+      ],
+      "type": "string"
+    },
+    "CircomSindri": {
+      "title": "CircomSindri",
+      "description": "Circom Sindri Manifest",
+      "type": "object",
+      "properties": {
+        "circuitType": {
+          "$ref": "#/definitions/SindriCircuitTypeOptions"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "curve": {
+          "default": "bn254",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CircomCurveOptions"
+            }
+          ]
+        },
+        "provingScheme": {
+          "default": "groth16",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CircomProvingSchemeOptions"
+            }
+          ]
+        },
+        "witnessCompiler": {
+          "default": "c++",
+          "allOf": [
+            {
+              "$ref": "#/definitions/CircomWitnessCompilerOptions"
+            }
+          ]
+        }
+      },
+      "required": [
+        "circuitType",
+        "name"
+      ]
+    },
+    "GnarkCurveOptions": {
+      "title": "GnarkCurveOptions",
+      "description": "An enumeration.",
+      "enum": [
+        "bls12-377",
+        "bls12-381",
+        "bls24-315",
+        "bn254",
+        "bw6-633",
+        "bw6-761"
+      ],
+      "type": "string"
+    },
+    "GnarkVersionOptions": {
+      "title": "GnarkVersionOptions",
+      "description": "An enumeration.",
+      "enum": [
+        "v0.8.1",
+        "v0.9.0"
+      ],
+      "type": "string"
+    },
+    "GnarkProvingSchemeOptions": {
+      "title": "GnarkProvingSchemeOptions",
+      "description": "An enumeration.",
+      "enum": [
+        "groth16"
+      ],
+      "type": "string"
+    },
+    "GnarkSindri": {
+      "title": "GnarkSindri",
+      "description": "Gnark Sindri Manifest",
+      "type": "object",
+      "properties": {
+        "circuitType": {
+          "$ref": "#/definitions/SindriCircuitTypeOptions"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "circuitStructName": {
+          "title": "Circuit Struct Name",
+          "type": "string"
+        },
+        "curve": {
+          "default": "bn254",
+          "allOf": [
+            {
+              "$ref": "#/definitions/GnarkCurveOptions"
+            }
+          ]
+        },
+        "gnarkVersion": {
+          "$ref": "#/definitions/GnarkVersionOptions"
+        },
+        "packageName": {
+          "title": "Package Name",
+          "type": "string"
+        },
+        "provingScheme": {
+          "default": "groth16",
+          "allOf": [
+            {
+              "$ref": "#/definitions/GnarkProvingSchemeOptions"
+            }
+          ]
+        }
+      },
+      "required": [
+        "circuitType",
+        "name",
+        "circuitStructName",
+        "gnarkVersion",
+        "packageName"
+      ]
+    },
+    "Halo2VersionOptions": {
+      "title": "Halo2VersionOptions",
+      "description": "An enumeration.",
+      "enum": [
+        "axiom-v0.2.2",
+        "axiom-v0.3.0",
+        "chiquito"
+      ],
+      "type": "string"
+    },
+    "Halo2AxiomV022Sindri": {
+      "title": "Halo2AxiomV022Sindri",
+      "description": "Halo2 Axiom V0.2.2 Sindri Manifest",
+      "type": "object",
+      "properties": {
+        "circuitType": {
+          "$ref": "#/definitions/SindriCircuitTypeOptions"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "className": {
+          "title": "Class Name",
+          "type": "string"
+        },
+        "degree": {
+          "title": "Degree",
+          "type": "integer"
+        },
+        "halo2Version": {
+          "$ref": "#/definitions/Halo2VersionOptions"
+        },
+        "packageName": {
+          "title": "Package Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "circuitType",
+        "name",
+        "className",
+        "degree",
+        "halo2Version",
+        "packageName"
+      ]
+    },
+    "Halo2AxiomV030Sindri": {
+      "title": "Halo2AxiomV030Sindri",
+      "description": "Halo2 Axiom V0.3.0 Sindri Manifest",
+      "type": "object",
+      "properties": {
+        "circuitType": {
+          "$ref": "#/definitions/SindriCircuitTypeOptions"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "className": {
+          "title": "Class Name",
+          "type": "string"
+        },
+        "degree": {
+          "title": "Degree",
+          "type": "integer"
+        },
+        "halo2Version": {
+          "$ref": "#/definitions/Halo2VersionOptions"
+        },
+        "packageName": {
+          "title": "Package Name",
+          "type": "string"
+        },
+        "threadBuilder": {
+          "title": "Thread Builder",
+          "enum": [
+            "GateThreadBuilder",
+            "RlcThreadBuilder"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "circuitType",
+        "name",
+        "className",
+        "degree",
+        "halo2Version",
+        "packageName",
+        "threadBuilder"
+      ]
+    },
+    "Halo2ChiquitoSindri": {
+      "title": "Halo2ChiquitoSindri",
+      "description": "Halo2 Chiquito Sindri Manifest",
+      "type": "object",
+      "properties": {
+        "circuitType": {
+          "$ref": "#/definitions/SindriCircuitTypeOptions"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "className": {
+          "title": "Class Name",
+          "type": "string"
+        },
+        "degree": {
+          "title": "Degree",
+          "type": "integer"
+        },
+        "halo2Version": {
+          "$ref": "#/definitions/Halo2VersionOptions"
+        },
+        "packageName": {
+          "title": "Package Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "circuitType",
+        "name",
+        "className",
+        "degree",
+        "halo2Version",
+        "packageName"
+      ]
+    },
+    "NoirProvingSchemeOptions": {
+      "title": "NoirProvingSchemeOptions",
+      "description": "An enumeration.",
+      "enum": [
+        "barretenberg"
+      ],
+      "type": "string"
+    },
+    "NoirSindri": {
+      "title": "NoirSindri",
+      "description": "Noir Sindri Manifest",
+      "type": "object",
+      "properties": {
+        "circuitType": {
+          "$ref": "#/definitions/SindriCircuitTypeOptions"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "provingScheme": {
+          "default": "barretenberg",
+          "allOf": [
+            {
+              "$ref": "#/definitions/NoirProvingSchemeOptions"
+            }
+          ]
+        }
+      },
+      "required": [
+        "circuitType",
+        "name"
+      ]
+    }
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,6 +4,7 @@ import { argv, exit } from "process";
 import { Command } from "@commander-js/extra-typings";
 
 import { Config, configCommand } from "cli/config";
+import { lintCommand } from "cli/lint";
 import { logger } from "cli/logging";
 import { loginCommand } from "cli/login";
 import { logoutCommand } from "cli/logout";
@@ -21,6 +22,7 @@ export const program = new Command()
     false,
   )
   .addCommand(configCommand)
+  .addCommand(lintCommand)
   .addCommand(loginCommand)
   .addCommand(logoutCommand)
   .addCommand(whoamiCommand)

--- a/src/cli/lint.ts
+++ b/src/cli/lint.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "fs";
+import { existsSync, readFileSync } from "fs";
 import path from "path";
 import process from "process";
 
@@ -35,4 +35,23 @@ export const lintCommand = new Command()
     const rootDirectory = path.dirname(sindriJsonPath);
     logger.debug(`Changing current directory to "${rootDirectory}".`);
     process.chdir(directoryPath);
+
+    // Load `sindri.json`.
+    let sindriJson: object = {};
+    try {
+      const sindriJsonContent = readFileSync(sindriJsonPath, {
+        encoding: "utf-8",
+      });
+      sindriJson = JSON.parse(sindriJsonContent);
+      logger.debug(
+        `Successfully loaded "sindri.json" from "${sindriJsonPath}":`,
+      );
+      logger.debug(sindriJson);
+    } catch (error) {
+      logger.fatal(
+        `Error loading "${sindriJsonPath}", perhaps it is not valid JSON?`,
+      );
+      logger.error(error);
+      return process.exit(1);
+    }
   });

--- a/src/cli/lint.ts
+++ b/src/cli/lint.ts
@@ -92,7 +92,9 @@ export const lintCommand = new Command()
           error.property
             .replace(/^instance/, "sindri.json")
             .replace(/\./g, ":") +
-          (error.schema.title ? `:${error.schema.title}` : "");
+          (typeof error.schema === "object" && error.schema.title
+            ? `:${error.schema.title}`
+            : "");
         logger.error(`${prefix} ${error.message}`);
         errorCount += 1;
       }

--- a/src/cli/lint.ts
+++ b/src/cli/lint.ts
@@ -11,10 +11,10 @@ import { findFileUpwards, loadSindriManifestJsonSchema } from "cli/utils";
 
 export const lintCommand = new Command()
   .name("lint")
-  .description("Lint the current `sindri.json` project for potential issues.")
+  .description("Lint the current Sindri project for potential issues.")
   .argument(
     "[directory]",
-    "The directory where the new project should be initialized.",
+    "The directory, or subdirectory, of the project to lint.",
     ".",
   )
   .action(async (directory) => {

--- a/src/cli/lint.ts
+++ b/src/cli/lint.ts
@@ -1,0 +1,38 @@
+import { existsSync } from "fs";
+import path from "path";
+import process from "process";
+
+import { Command } from "@commander-js/extra-typings";
+
+import { logger } from "cli/logging";
+import { findFileUpwards } from "cli/utils";
+
+export const lintCommand = new Command()
+  .name("lint")
+  .description("Lint the current `sindri.json` project for potential issues.")
+  .argument(
+    "[directory]",
+    "The directory where the new project should be initialized.",
+    ".",
+  )
+  .action(async (directory) => {
+    // Find `sindri.json` and move into the root of the project directory.
+    const directoryPath = path.resolve(directory);
+    if (!existsSync(directoryPath)) {
+      logger.error(
+        `The "${directoryPath}" directory does not exist. Aborting.`,
+      );
+      return process.exit(1);
+    }
+    const sindriJsonPath = findFileUpwards(/^sindri.json$/i, directoryPath);
+    if (!sindriJsonPath) {
+      logger.error(
+        `No "sindri.json" file was found in or above "${directoryPath}". Aborting.`,
+      );
+      return process.exit(1);
+    }
+    logger.debug(`Found "sindri.json" at "${sindriJsonPath}".`);
+    const rootDirectory = path.dirname(sindriJsonPath);
+    logger.debug(`Changing current directory to "${rootDirectory}".`);
+    process.chdir(directoryPath);
+  });

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -2,6 +2,7 @@ import { readdirSync, readFileSync } from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 
+import type { Schema } from "jsonschema";
 import type { PackageJson } from "type-fest";
 
 const currentFilePath = fileURLToPath(import.meta.url);
@@ -52,6 +53,20 @@ export function loadPackageJson(): PackageJson {
   });
   const packageJson: PackageJson = JSON.parse(packageJsonContent);
   return packageJson;
+}
+
+/**
+ * Loads the project's `sindri-manifest.json` file.
+ *
+ * @returns The contents of `sindri-manifest.json`.
+ */
+export function loadSindriManifestJsonSchema(): Schema {
+  const sindriManifestJsonPath = findFileUpwards("sindri-manifest.json");
+  const sindriManifestJsonContent = readFileSync(sindriManifestJsonPath, {
+    encoding: "utf-8",
+  });
+  const sindriManifestJson: Schema = JSON.parse(sindriManifestJsonContent);
+  return sindriManifestJson;
 }
 
 /**

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -62,6 +62,11 @@ export function loadPackageJson(): PackageJson {
  */
 export function loadSindriManifestJsonSchema(): Schema {
   const sindriManifestJsonPath = findFileUpwards("sindri-manifest.json");
+  if (!sindriManifestJsonPath) {
+    throw new Error(
+      "A `sindri-manifest.json` file was unexpectedly not found.",
+    );
+  }
   const sindriManifestJsonContent = readFileSync(sindriManifestJsonPath, {
     encoding: "utf-8",
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1508,6 +1508,11 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonschema@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.4.1.tgz#cc4c3f0077fb4542982973d8a083b6b34f482dab"
+  integrity sha512-S6cATIPVv1z0IlxdN+zUk5EPjkGCdnhN4wVSBlvoUO1tOLJootbo9CquNJmbIh4yikWHiUedhRYrNPn1arpEmQ==
+
 keyv@^4.5.3:
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz#a879a99e29452f942439f2a405e3af8b31d4de93"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1626,6 +1626,11 @@ minimatch@^5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
+minimist@1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
+
 minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
@@ -2265,6 +2270,11 @@ tsup@^7.3.0:
     sucrase "^3.20.3"
     tree-kill "^1.2.2"
 
+tunnel@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz#72f1314b34a5b192db012324df2cc587ca47f92c"
+  integrity sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==
+
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.4.0.tgz#07b8203bfa7056c0657050e3ccd2c37730bab8f1"
@@ -2328,6 +2338,14 @@ webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
+
+wget-improved@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/wget-improved/-/wget-improved-3.4.0.tgz#da4d2578e46c6ed8532e6d34cbdf8c7344fdd17c"
+  integrity sha512-mHCdqImHntGzaauaQrfhkcHO0sAOp9Fd/9v5PXwrvHK+nggRWG9en5UH72/WitJFv3d3iFwJSAVMrRaCjW6dAA==
+  dependencies:
+    minimist "1.2.6"
+    tunnel "0.0.6"
 
 whatwg-url@^7.0.0:
   version "7.1.0"


### PR DESCRIPTION
This adds npm scripts to download the Sindri Manifest JSON Schema from the backend. Currently it's stored at the root of the project. It can be updated by running:

```bash
yarn download-sindri-manifest-schema
```

This also adds a `sindri lint` command which validates a project's `sindri.json` file against the schema. It also checks for a `README.md` file and logs it as a warning if it is not found. We can add more checks in the future.
