### PR TITLE
Add a `sindri deploy` command

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,5 +13,7 @@ module.exports = {
     ecmaVersion: 2020,
     sourceType: "module",
   },
-  rules: {},
+  rules: {
+    "no-constant-condition": ["error", { checkLoops: false }],
+  },
 };

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "commander": "^11.1.0",
     "env-paths": "^2.2.1",
     "form-data": "^4.0.0",
+    "ignore-walk": "^6.0.4",
     "jsonschema": "^1.4.1",
     "lodash": "^4.17.21",
     "pino": "^8.16.2",
@@ -63,6 +64,7 @@
   "devDependencies": {
     "@commander-js/extra-typings": "^11.1.0",
     "@tsconfig/node18": "^18.2.2",
+    "@types/ignore-walk": "^4.0.3",
     "@types/lodash": "^4.14.202",
     "@types/node": "^20.9.1",
     "@typescript-eslint/eslint-plugin": "^6.11.0",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@types/ignore-walk": "^4.0.3",
     "@types/lodash": "^4.14.202",
     "@types/node": "^20.9.1",
+    "@types/tar": "^6.1.10",
     "@typescript-eslint/eslint-plugin": "^6.11.0",
     "@typescript-eslint/parser": "^6.11.0",
     "eslint": "^8.53.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
   "name": "sindri",
   "version": "0.0.0",
   "description": "The Sindri Labs JavaScript SDK and CLI tool.",
-  "files": ["dist/", "src/", "sindri-manifest.json"],
+  "files": [
+    "dist/",
+    "src/",
+    "sindri-manifest.json"
+  ],
   "main": "dist/lib/index.js",
   "module": "dist/lib/index.mjs",
   "bin": {
@@ -53,6 +57,7 @@
     "pino": "^8.16.2",
     "pino-pretty": "^10.2.3",
     "rc": "^1.2.8",
+    "tar": "^6.2.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/src/cli/deploy.ts
+++ b/src/cli/deploy.ts
@@ -1,0 +1,169 @@
+import { existsSync, readFileSync } from "fs";
+import path from "path";
+import process from "process";
+
+import { Command } from "@commander-js/extra-typings";
+import FormData from "form-data";
+import walk from "ignore-walk";
+import tar from "tar";
+
+import { Config } from "cli/config";
+import { logger } from "cli/logging";
+import { findFileUpwards } from "cli/utils";
+import { ApiError, CircuitsService, CircuitStatus } from "lib/api";
+
+export const deployCommand = new Command()
+  .name("deploy")
+  .description("Deploy the current Sindri project.")
+  .argument("[directory]", "The location of the Sindri project to deploy.", ".")
+  .action(async (directory) => {
+    // Find `sindri.json` and move into the root of the project directory.
+    const directoryPath = path.resolve(directory);
+    if (!existsSync(directoryPath)) {
+      logger.error(
+        `The "${directoryPath}" directory does not exist. Aborting.`,
+      );
+      return process.exit(1);
+    }
+    const sindriJsonPath = findFileUpwards(/^sindri.json$/i, directoryPath);
+    if (!sindriJsonPath) {
+      logger.error(
+        `No "sindri.json" file was found in or above "${directoryPath}". Aborting.`,
+      );
+      return process.exit(1);
+    }
+    logger.debug(`Found "sindri.json" at "${sindriJsonPath}".`);
+    const rootDirectory = path.dirname(sindriJsonPath);
+    logger.debug(`Changing current directory to "${rootDirectory}".`);
+    process.chdir(directoryPath);
+
+    // Load `sindri.json`.
+    let sindriJson: object = {};
+    try {
+      const sindriJsonContent = readFileSync(sindriJsonPath, {
+        encoding: "utf-8",
+      });
+      sindriJson = JSON.parse(sindriJsonContent);
+      logger.debug(
+        `Successfully loaded "sindri.json" from "${sindriJsonPath}":`,
+      );
+      logger.debug(sindriJson);
+    } catch (error) {
+      logger.fatal(
+        `Error loading "${sindriJsonPath}", perhaps it is not valid JSON?`,
+      );
+      logger.error(error);
+      return process.exit(1);
+    }
+    if (!("name" in sindriJson)) {
+      logger.error('No "name" field found in "sindri.json". Aborting.');
+      return process.exit(1);
+    }
+    const circuitName = sindriJson.name;
+
+    // Authorize the API client.
+    const config = new Config();
+    const auth = config.auth;
+    if (!auth) {
+      logger.warn("You must login first with `sindri login`.");
+      return process.exit(1);
+    }
+
+    // Create a project tarball and prepare the form data for upload.
+    const files = walk.sync({
+      follow: true,
+      ignoreFiles: [".gitignore", ".sindriignore"],
+      path: ".",
+    });
+    const formData = new FormData();
+    const tarballFilename = `${circuitName}.tar.gz`;
+    logger.info(
+      `Creating "${tarballFilename}" tarball with ${files.length} files.`,
+    );
+    formData.append(
+      "files",
+      // ts-expect-error - @types/tar doesn't handle the `sync` option correctly.
+      tar
+        .c(
+          {
+            gzip: true,
+            onwarn: (code: string, message: string) => {
+              logger.warn(`While creating tarball: ${code} - ${message}`);
+            },
+            prefix: `${circuitName}/`,
+            sync: true,
+          },
+          files,
+        )
+        .read(),
+      {
+        filename: tarballFilename,
+      },
+    );
+
+    // Upload the tarball.
+    let circuitId: string | undefined;
+    try {
+      const response = await CircuitsService.circuitCreate(formData);
+      circuitId = response.circuit_id;
+      logger.debug("/api/v1/circuit/create/ response:");
+      logger.debug(response);
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 401) {
+        logger.error(
+          "Your credentials are invalid. Please log in again with `sindri login`.",
+        );
+      } else {
+        logger.fatal("An unknown error occurred.");
+        logger.error(error);
+        return process.exit(1);
+      }
+    }
+    if (!circuitId) {
+      logger.error("No circuit ID was returned from the API. Aborting.");
+      return process.exit(1);
+    }
+
+    // Poll for circuit compilation to complete.
+    const startTime = Date.now();
+    let previousStatus: CircuitStatus | undefined;
+    while (true) {
+      try {
+        logger.debug("Polling for circuit compilation status.");
+        const response = await CircuitsService.circuitDetail(circuitId, false);
+
+        // Only log this when the status changes because it's noisy.
+        if (previousStatus !== response.status) {
+          previousStatus = response.status;
+          logger.debug(`/api/v1/circuit/${circuitId}/detail/ response:`);
+          logger.debug(response);
+        }
+
+        const elapsedSeconds = ((Date.now() - startTime) / 1000).toFixed(1);
+        if (response.status === CircuitStatus.READY) {
+          logger.info(
+            `Circuit compiled successfully after ${elapsedSeconds} seconds.`,
+          );
+          break;
+        } else if (response.status === CircuitStatus.FAILED) {
+          logger.error(
+            `Circuit compilation failed after ${elapsedSeconds} seconds: ` +
+              (response.error ?? "Unknown error."),
+          );
+          return process.exit(1);
+        } else if (response.status === CircuitStatus.QUEUED) {
+          logger.debug("Circuit compilation is queued.");
+        } else if (response.status === CircuitStatus.IN_PROGRESS) {
+          logger.debug("Circuit compilation is in progress");
+        }
+      } catch (error) {
+        logger.fatal(
+          "An unknown error occurred while polling for compilation to finish.",
+        );
+        logger.error(error);
+        return process.exit(1);
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+  });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -4,6 +4,7 @@ import { argv, exit } from "process";
 import { Command } from "@commander-js/extra-typings";
 
 import { Config, configCommand } from "cli/config";
+import { deployCommand } from "cli/deploy";
 import { lintCommand } from "cli/lint";
 import { logger } from "cli/logging";
 import { loginCommand } from "cli/login";
@@ -22,6 +23,7 @@ export const program = new Command()
     false,
   )
   .addCommand(configCommand)
+  .addCommand(deployCommand)
   .addCommand(lintCommand)
   .addCommand(loginCommand)
   .addCommand(logoutCommand)

--- a/src/lib/api/core/request.ts
+++ b/src/lib/api/core/request.ts
@@ -119,6 +119,12 @@ export const getFormData = (
   options: ApiRequestOptions,
 ): FormData | undefined => {
   if (options.formData) {
+    // This is a manual edit to allow `FormData` to be passed in directly.
+    // DO NOT REMOVE THIS!
+    if (options.formData instanceof FormData) {
+      return options.formData;
+    }
+
     const formData = new FormData();
 
     const process = (key: string, value: any) => {

--- a/src/lib/api/services/CircuitsService.ts
+++ b/src/lib/api/services/CircuitsService.ts
@@ -2,6 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+import type FormData from "form-data";
 import type { CircomCircuitInfoResponse } from "../models/CircomCircuitInfoResponse";
 import type { GnarkCircuitInfoResponse } from "../models/GnarkCircuitInfoResponse";
 import type { Halo2CircuitInfoResponse } from "../models/Halo2CircuitInfoResponse";
@@ -50,9 +51,13 @@ export class CircuitsService {
    * @returns any Created
    * @throws ApiError
    */
-  public static circuitCreate(formData: {
-    files: Array<Blob>;
-  }): CancelablePromise<
+  public static circuitCreate(
+    formData: // This is a manual edit to allow `FormData` to be passed in directly:
+    | FormData // DO NOT REMOVE THIS!
+      | {
+          files: Array<Blob>;
+        },
+  ): CancelablePromise<
     | CircomCircuitInfoResponse
     | Halo2CircuitInfoResponse
     | GnarkCircuitInfoResponse

--- a/yarn.lock
+++ b/yarn.lock
@@ -437,6 +437,13 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node18/-/node18-18.2.2.tgz#81fb16ecff0d400b1cbadbf76713b50f331029ce"
   integrity sha512-d6McJeGsuoRlwWZmVIeE8CUA27lu6jLjvv1JzqmpsytOYYbVi1tHZEnwCNVOXnj4pyLvneZlFlpXUK+X9wBWyw==
 
+"@types/ignore-walk@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@types/ignore-walk/-/ignore-walk-4.0.3.tgz#15839e8aa30275bb65a4db2ad159d87351a63787"
+  integrity sha512-6V7wDsk0nz8LtRC7qeC0GfXadFLT4FdCtVbXhxoIGRdkn2kLr20iMLupRGiBhlZ79WWWqaObIdR3nkXfUrBPdQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/json-schema@^7.0.12", "@types/json-schema@^7.0.6":
   version "7.0.15"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
@@ -1368,6 +1375,13 @@ ieee754@^1.2.1:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
+ignore-walk@^6.0.4:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/ignore-walk/-/ignore-walk-6.0.4.tgz#89950be94b4f522225eb63a13c56badb639190e9"
+  integrity sha512-t7sv42WkwFkyKbivUCglsQW5YWMskWtbEf4MNKX5u/CCWHKSPzN4FtBQGsQZgCLbxOzpVlcbWVK5KB3auIOjSw==
+  dependencies:
+    minimatch "^9.0.0"
+
 ignore@^5.2.0, ignore@^5.2.4:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.0.tgz#67418ae40d34d6999c95ff56016759c718c82f78"
@@ -1635,6 +1649,13 @@ minimatch@^5.0.1:
   version "5.1.6"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
   integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
+  dependencies:
+    brace-expansion "^2.0.1"
+
+minimatch@^9.0.0:
+  version "9.0.3"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.3.tgz#a6e00c3de44c3a542bfaae70abfc22420a6da825"
+  integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
   dependencies:
     brace-expansion "^2.0.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -473,6 +473,14 @@
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.5.tgz#deed5ab7019756c9c90ea86139106b0346223f35"
   integrity sha512-+d+WYC1BxJ6yVOgUgzK8gWvp5qF8ssV5r4nsDcZWKRWcDQLQ619tvWAxJQYGgBrO1MnLJC7a5GtiYsAoQ47dJg==
 
+"@types/tar@^6.1.10":
+  version "6.1.10"
+  resolved "https://registry.yarnpkg.com/@types/tar/-/tar-6.1.10.tgz#10b0e12129f4af5909af82a055837116ab06f860"
+  integrity sha512-60ZO+W0tRKJ3ggdzJKp75xKVlNogKYMqGvr2bMH/+k3T0BagfYTnbmVDFMJB1BFttz6yRgP5MDGP27eh7brrqw==
+  dependencies:
+    "@types/node" "*"
+    minipass "^4.0.0"
+
 "@types/wrap-ansi@^3.0.0":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz#18b97a972f94f60a679fd5c796d96421b9abb9fd"
@@ -1675,6 +1683,11 @@ minipass@^3.0.0:
   integrity sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==
   dependencies:
     yallist "^4.0.0"
+
+minipass@^4.0.0:
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-4.2.8.tgz#f0010f64393ecfc1d1ccb5f582bcaf45f48e1a3a"
+  integrity sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==
 
 minipass@^5.0.0:
   version "5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -768,6 +768,11 @@ chokidar@^3.5.1:
   optionalDependencies:
     fsevents "~2.3.2"
 
+chownr@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
+  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
+
 cli-spinners@^2.9.1:
   version "2.9.1"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.9.1.tgz#9c0b9dad69a6d47cbb4333c14319b060ed395a35"
@@ -1216,6 +1221,13 @@ fs-extra@^11.1.1:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
+fs-minipass@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
+  integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
+  dependencies:
+    minipass "^3.0.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -1635,6 +1647,31 @@ minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
+minipass@^3.0.0:
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.3.6.tgz#7bba384db3a1520d18c9c0e5251c3444e95dd94a"
+  integrity sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==
+  dependencies:
+    yallist "^4.0.0"
+
+minipass@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-5.0.0.tgz#3e9788ffb90b694a5d0ec94479a45b5d8738133d"
+  integrity sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==
+
+minizlib@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
+  integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
+  dependencies:
+    minipass "^3.0.0"
+    yallist "^4.0.0"
+
+mkdirp@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 ms@2.1.2:
   version "2.1.2"
@@ -2177,6 +2214,18 @@ synckit@^0.8.5:
   dependencies:
     "@pkgr/utils" "^2.3.1"
     tslib "^2.5.0"
+
+tar@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.2.0.tgz#b14ce49a79cb1cd23bc9b016302dea5474493f73"
+  integrity sha512-/Wo7DcT0u5HUV486xg675HtjNd3BXZ6xDbzsCUZPt5iw8bTQ63bP0Raut3mvro9u+CUyq7YQd8Cx55fsZXxqLQ==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^5.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
 
 text-table@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
This adds a basic `sindri deploy` command to upload and compile a circuit. The generated OpenAPI client unfortunately didn't support passing in `FormData` directly, so I made some small manual edits to the generated code... This is unfortunate because it will be overwritten when we regenerate the client, I'll loop back and come up with a better fix later.
