### PR TITLE
Disallow hyphens in Noir package names in `sindri init`

### DIFF
--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -223,17 +223,18 @@ export const initCommand = new Command()
         message: "Noir Package Name:",
         default: circuitName
           .toLowerCase()
-          .replace(/^[^a-z0-9_]*/, "")
-          .replace(/-+/g, "-"),
+          .replace(/[- ]/g, "_")
+          .replace(/^[^a-z]*/, "")
+          .replace(/[^a-z0-9_]*/, "")
+          .replace(/_+/g, "_"),
         validate: (input): boolean | string => {
           if (input.length === 0) {
             return "You must specify a package name.";
           }
-          if (!/^[a-z0-9_]+(?:-[a-z0-9_]+)*$$/.test(input)) {
+          if (!/^[a-z][a-z0-9_]*$/.test(input)) {
             return (
-              "Package names must begin with a lowercase letter, number, or underscore, and only " +
-              "be followed by lowercase or numeric characters and underscores (optionally " +
-              "separated hyphens)."
+              "Package names must start with a lowercase letter and only be followed by " +
+              "lowercase letters, digits, and underscores."
             );
           }
           return true;

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -224,18 +224,14 @@ export const initCommand = new Command()
         default: circuitName
           .toLowerCase()
           .replace(/[- ]/g, "_")
-          .replace(/^[^a-z]*/, "")
-          .replace(/[^a-z0-9_]*/, "")
+          .replace(/[^a-zA-Z0-9_]+/, "")
           .replace(/_+/g, "_"),
         validate: (input): boolean | string => {
           if (input.length === 0) {
             return "You must specify a package name.";
           }
-          if (!/^[a-z][a-z0-9_]*$/.test(input)) {
-            return (
-              "Package names must start with a lowercase letter and only be followed by " +
-              "lowercase letters, digits, and underscores."
-            );
+          if (!/^[a-zA-Z0-9_]+$/.test(input)) {
+            return "Package names must only contain alphanumeric characters and underscores.";
           }
           return true;
         },


### PR DESCRIPTION
This updates the `sindri init` command logic around validating Noir package names to disallow hyphens. Through trial and error, I found that it seems to be fine with any mix of alphanumeric chacters and underscores, so I also relaxed the validation around this. I think that the package name is never used in code, unlike the Halo2 package names, and that's why it's OK for it to start with a digit even though that wouldn't be a valid code identifier.
