### PR TITLE
Switch "Team"->"Organization" in user-facing messages

### DIFF
--- a/src/cli/login.ts
+++ b/src/cli/login.ts
@@ -89,7 +89,7 @@ export const loginCommand = new Command()
       logger.debug("/api/v1/user/me/ response:");
       logger.debug(userResult);
       const teamId = await select({
-        message: "Select a Team:",
+        message: "Select a Organization:",
         choices: userResult.teams.map(({ id, slug }) => ({
           name: slug,
           value: id,
@@ -97,7 +97,7 @@ export const loginCommand = new Command()
       });
       const team = userResult.teams.find((team) => team.id === teamId);
       if (!team) {
-        throw new Error("No team selected.");
+        throw new Error("No organization selected.");
       }
 
       // Generate an API key.

--- a/src/cli/whoami.ts
+++ b/src/cli/whoami.ts
@@ -8,7 +8,7 @@ import { ApiError, InternalService } from "lib/api";
 
 export const whoamiCommand = new Command()
   .name("whoami")
-  .description("Display the currently authorized team name.")
+  .description("Display the currently authorized organization name.")
   .action(async () => {
     // Authorize the API client.
     const config = new Config();


### PR DESCRIPTION
The name "team" is used internally in the API, but we want to use the name "Organization" for anything user-facing.
