### PR TITLE
Integrate nock for HTTP request recording in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,8 @@
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.1",
     "jsdom": "^23.0.1",
+    "nock": "^13.4.0",
+    "nock-puppeteer": "^14.4.1",
     "openapi-typescript-codegen": "^0.25.0",
     "prettier": "^3.1.0",
     "puppeteer": "^21.7.0",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "eslint": "^8.53.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.1",
-    "jsdom": "^23.0.1",
     "nock": "^13.4.0",
     "nock-puppeteer": "^14.4.1",
     "openapi-typescript-codegen": "^0.25.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,9 @@
     "test:browser": "ava --config test/ava.config.browser.mjs",
     "test:browser:record": "NOCK_BACK_MODE=update ava --config test/ava.config.browser.mjs",
     "test:dev": "ava --config test/ava.config.dev.mjs",
+    "test:dev:record": "NODE_BACK_MODE=update ava --config test/ava.config.dev.mjs",
     "test:node": "ava --config test/ava.config.node.mjs",
+    "test:node:record": "NODE_BACK_MODE=update ava --config test/ava.config.node.mjs",
     "type-check": "tsc --noEmit"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "lint": "eslint '**/*.{js,ts}'",
     "format": "prettier --write '**/*.{js,json,md,ts}'",
     "test:browser": "ava --config test/ava.config.browser.mjs",
+    "test:browser:record": "NOCK_BACK_MODE=update ava --config test/ava.config.browser.mjs",
     "test:dev": "ava --config test/ava.config.dev.mjs",
     "test:node": "ava --config test/ava.config.node.mjs",
     "type-check": "tsc --noEmit"

--- a/test/ava.config.base.mjs
+++ b/test/ava.config.base.mjs
@@ -4,4 +4,6 @@ export default {
   },
   files: ["test/**/*.test.ts"],
   nodeArguments: ["--loader=tsx"],
+  // Use child processes instead of threads because notch isn't thread safe.
+  workerThreads: false,
 };

--- a/test/ava.config.base.mjs
+++ b/test/ava.config.base.mjs
@@ -1,9 +1,17 @@
+import process from "process";
+
 export default {
   extensions: {
     ts: "module",
   },
   files: ["test/**/*.test.ts"],
   nodeArguments: ["--loader=tsx"],
+  // Increase the timeout if we expect to make live API calls.
+  timeout: ["dryrun", "record", "update", "wild"].includes(
+    process.NOCK_BACK_MODE ?? "lockdown",
+  )
+    ? 60000
+    : 10000,
   // Use child processes instead of threads because notch isn't thread safe.
   workerThreads: false,
 };

--- a/test/ava.config.base.mjs
+++ b/test/ava.config.base.mjs
@@ -8,10 +8,10 @@ export default {
   nodeArguments: ["--loader=tsx"],
   // Increase the timeout if we expect to make live API calls.
   timeout: ["dryrun", "record", "update", "wild"].includes(
-    process.NOCK_BACK_MODE ?? "lockdown",
+    process.env.NOCK_BACK_MODE ?? "lockdown",
   )
-    ? 60000
-    : 10000,
+    ? "60s"
+    : "10s",
   // Use child processes instead of threads because notch isn't thread safe.
   workerThreads: false,
 };

--- a/test/browser/fixtures/main.test.ts.json
+++ b/test/browser/fixtures/main.test.ts.json
@@ -1,0 +1,1019 @@
+[
+    {
+        "scope": "https://sindri.app:443",
+        "method": "get",
+        "path": "/robots.txt",
+        "body": "",
+        "status": 200,
+        "response": "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\"/><meta name=\"viewport\" content=\"width=device-width,initial-scale=1,shrink-to-fit=no\"/><meta name=\"mobile-web-app-capable\" content=\"yes\"/><meta name=\"format-detection\" content=\"telephone=no\"/><title>Sindri</title><link rel=\"preconnect\" href=\"https://fonts.googleapis.com\"/><link rel=\"preconnect\" href=\"https://fonts.gstatic.com\" crossorigin/><link href=\"https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;800&display=swap\" rel=\"stylesheet\"/><script defer=\"defer\" src=\"/runtime.30ef403476e3e0b7e5126f2bf73adaf4.js\"></script><script defer=\"defer\" src=\"/npm.mui.0b911dc429e4a0063355e6727bfda865.js\"></script><script defer=\"defer\" src=\"/npm.core-js.4a4d82d0a402a1542119c48bec590bc2.js\"></script><script defer=\"defer\" src=\"/npm.moment.7ade13edecb1a25b3c7970b6cb2f3988.js\"></script><script defer=\"defer\" src=\"/npm.react-redux.9a6d3de1ceff07c4a1e29b3371cd73ed.js\"></script><script defer=\"defer\" src=\"/npm.emotion.f7332e6603cd98c6094b6f8899fcfa6b.js\"></script><script defer=\"defer\" src=\"/npm.redux-persist.4c4b78a1b7c8c7f327d4aeb3a7c23445.js\"></script><script defer=\"defer\" src=\"/npm.react-router.6f25fa7680daa338de5b4b74b5f8a2c2.js\"></script><script defer=\"defer\" src=\"/npm.react-transition-group.d98ae7fc5c853d3e99debcd8d05ddc19.js\"></script><script defer=\"defer\" src=\"/npm.reduxjs.6c9b43ff2be88131d7e53cd019f54782.js\"></script><script defer=\"defer\" src=\"/npm.floating-ui.627b2f7cd13096c7a6803d4e65f58ae9.js\"></script><script defer=\"defer\" src=\"/npm.styled-components.717cac08aa7d011c525fee66b5846991.js\"></script><script defer=\"defer\" src=\"/npm.react-dropzone.6188accaaa08e13a91b1464693bde3aa.js\"></script><script defer=\"defer\" src=\"/npm.react-dom.689ade6574851e1962f847b3d5b8bfa5.js\"></script><script defer=\"defer\" src=\"/npm.sweetalert2.5f59dfd36c3ecbb9cd472c0e76133d6b.js\"></script><script defer=\"defer\" src=\"/npm.popperjs.4789ecd07935921773dffa5dfdbdbed5.js\"></script><script defer=\"defer\" src=\"/895.208c34bb5c3ecb0422a91ceaa91094d4.js\"></script><script defer=\"defer\" src=\"/main.6f83d425c82354878fbbaf1db76ab982.js\"></script><meta name=\"apple-mobile-web-app-title\" content=\"React Boilerplate\" /><meta name=\"apple-mobile-web-app-capable\" content=\"yes\" /><meta name=\"apple-mobile-web-app-status-bar-style\" content=\"default\" /><meta name=\"theme-color\" content=\"#b1624d\" /><link rel=\"apple-touch-icon\" sizes=\"180x180\" href=\"/icon_180x180.63c71ff1fe800fe7fc6a16584342cb4c.png\" /><link rel=\"apple-touch-icon\" sizes=\"167x167\" href=\"/icon_167x167.359d468d6c991c5c01aa3cdcfaeea8bd.png\" /><link rel=\"apple-touch-icon\" sizes=\"152x152\" href=\"/icon_152x152.3b0f40a9c71e9ad8aa01e085feaa48f7.png\" /><link rel=\"apple-touch-icon\" sizes=\"120x120\" href=\"/icon_120x120.f51c13266175c3794ce042c18f41966b.png\" /><link rel=\"manifest\" href=\"/manifest.8259ad0cff5bad38962209630528b19c.json\" /></head><body><noscript>If you're seeing this message, that means <strong>JavaScript has been disabled on your browser</strong>, please <strong>enable JS</strong> to make this app work.</noscript><div id=\"app\"></div><link href=\"https://cdn.jsdelivr.net/npm/@sweetalert2/theme-material-ui/material-ui.css\" rel=\"stylesheet\"/></body></html>",
+        "rawHeaders": [
+            "Accept-Ranges",
+            "bytes",
+            "Cache-Control",
+            "public, no-cache",
+            "Content-Length",
+            "3172",
+            "Content-Type",
+            "text/html",
+            "Date",
+            "Sat, 06 Jan 2024 05:42:14 GMT",
+            "Etag",
+            "\"658b31ce-c64\"",
+            "Last-Modified",
+            "Tue, 26 Dec 2023 20:04:30 GMT",
+            "Server",
+            "nginx/1.25.3",
+            "Connection",
+            "close"
+        ],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://sindri.app:443",
+        "method": "get",
+        "path": "/api/v1/sindri-manifest-schema.json",
+        "body": "",
+        "status": 200,
+        "response": {
+            "$id": "https://sindri.app/api/v1/sindri-manifest-schema.json",
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "title": "SindriManifest",
+            "description": "Sindri Manifest file schema for `sindri.json` files.",
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/CircomSindriManifest"
+                },
+                {
+                    "$ref": "#/definitions/GnarkSindriManifest"
+                },
+                {
+                    "$ref": "#/definitions/Halo2AxiomV022SindriManifest"
+                },
+                {
+                    "$ref": "#/definitions/Halo2AxiomV030SindriManifest"
+                },
+                {
+                    "$ref": "#/definitions/NoirSindriManifest"
+                }
+            ],
+            "definitions": {
+                "CircomCurveOptions": {
+                    "title": "CircomCurveOptions",
+                    "description": "The supported Circom curves.",
+                    "enum": [
+                        "bn254"
+                    ],
+                    "type": "string"
+                },
+                "CircomProvingSchemeOptions": {
+                    "title": "CircomProvingSchemeOptions",
+                    "description": "The supported Circom proving schemes.",
+                    "enum": [
+                        "groth16"
+                    ],
+                    "type": "string"
+                },
+                "CircomWitnessCompilerOptions": {
+                    "title": "CircomWitnessCompilerOptions",
+                    "description": "The supported Circom witness compilers.",
+                    "enum": [
+                        "c++",
+                        "wasm"
+                    ],
+                    "type": "string"
+                },
+                "CircomSindriManifest": {
+                    "title": "Sindri Manifest for Circom Circuits",
+                    "description": "Sindri Manifest for Circom circuits.",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "title": "Circuit Name",
+                            "description": "The circuit name used to uniquely identify the circuit within your organization. Similar to a GitHub project name or a Docker image name.",
+                            "pattern": "^[-a-zA-Z0-9_]+$",
+                            "error_messages": {
+                                "regex": "`name` must be a valid slug."
+                            },
+                            "type": "string"
+                        },
+                        "circuitType": {
+                            "title": "Circuit Type",
+                            "description": "The (frontend) development framework that your circuit is written with.",
+                            "enum": [
+                                "circom"
+                            ],
+                            "type": "string"
+                        },
+                        "curve": {
+                            "title": "Proving Curve",
+                            "description": "The curve over which the proof is executed.",
+                            "default": "bn254",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/CircomCurveOptions"
+                                }
+                            ]
+                        },
+                        "provingScheme": {
+                            "description": "The backend proving scheme.",
+                            "default": "groth16",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/CircomProvingSchemeOptions"
+                                }
+                            ]
+                        },
+                        "witnessCompiler": {
+                            "description": "The circuit witness compiler.",
+                            "default": "c++",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/CircomWitnessCompilerOptions"
+                                }
+                            ]
+                        },
+                        "$schema": {
+                            "type": "string",
+                            "title": "Sindri Manifest JSON Schema URL",
+                            "description": "The URL pointing to a Sindri JSON Manifest schema definition.",
+                            "examples": [
+                                "https://sindri.app/api/v1/sindri-manifest-schema.json"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "circuitType"
+                    ],
+                    "additionalProperties": false
+                },
+                "GnarkCurveOptions": {
+                    "title": "GnarkCurveOptions",
+                    "description": "The supported Gnark curves.",
+                    "enum": [
+                        "bls12-377",
+                        "bls12-381",
+                        "bls24-315",
+                        "bn254",
+                        "bw6-633",
+                        "bw6-761"
+                    ],
+                    "type": "string"
+                },
+                "GnarkVersionOptions": {
+                    "title": "GnarkVersionOptions",
+                    "description": "The supported Gnark framework versions.",
+                    "enum": [
+                        "v0.8.1",
+                        "v0.9.0"
+                    ],
+                    "type": "string"
+                },
+                "GnarkProvingSchemeOptions": {
+                    "title": "GnarkProvingSchemeOptions",
+                    "description": "The supported Gnark proving schemes.",
+                    "enum": [
+                        "groth16"
+                    ],
+                    "type": "string"
+                },
+                "GnarkSindriManifest": {
+                    "title": "Sindri Manifest for Gnark Circuits",
+                    "description": "Sindri Manifest for Gnark circuits.",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "title": "Circuit Name",
+                            "description": "The circuit name used to uniquely identify the circuit within your organization. Similar to a GitHub project name or a Docker image name.",
+                            "pattern": "^[-a-zA-Z0-9_]+$",
+                            "error_messages": {
+                                "regex": "`name` must be a valid slug."
+                            },
+                            "type": "string"
+                        },
+                        "circuitStructName": {
+                            "title": "Circuit Struct Name",
+                            "description": "The name of the Go struct which defines your circuit inputs.",
+                            "pattern": "^[A-Z][A-Za-z0-9_]*$",
+                            "error_messages": {
+                                "regex": "`circuitStructName` must be a valid Go exported struct name."
+                            },
+                            "type": "string"
+                        },
+                        "circuitType": {
+                            "title": "Circuit Type",
+                            "description": "The (frontend) development framework that your circuit is written with.",
+                            "enum": [
+                                "gnark"
+                            ],
+                            "type": "string"
+                        },
+                        "curve": {
+                            "title": "Proving Curve",
+                            "description": "The curve over which the proof is executed.",
+                            "default": "bn254",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/GnarkCurveOptions"
+                                }
+                            ]
+                        },
+                        "gnarkVersion": {
+                            "description": "The version of the Gnark framework that your circuit uses.",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/GnarkVersionOptions"
+                                }
+                            ]
+                        },
+                        "packageName": {
+                            "title": "Go Package Name",
+                            "description": "The name of the Go package containing your circuit definition.",
+                            "pattern": "^[a-z][a-z0-9]*$",
+                            "error_messages": {
+                                "regex": "`packageName` must be a valid Go package name."
+                            },
+                            "type": "string"
+                        },
+                        "provingScheme": {
+                            "description": "The backend proving scheme.",
+                            "default": "groth16",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/GnarkProvingSchemeOptions"
+                                }
+                            ]
+                        },
+                        "$schema": {
+                            "type": "string",
+                            "title": "Sindri Manifest JSON Schema URL",
+                            "description": "The URL pointing to a Sindri JSON Manifest schema definition.",
+                            "examples": [
+                                "https://sindri.app/api/v1/sindri-manifest-schema.json"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "circuitStructName",
+                        "circuitType",
+                        "gnarkVersion",
+                        "packageName"
+                    ],
+                    "additionalProperties": false
+                },
+                "Halo2ProvingSchemeOptions": {
+                    "title": "Halo2ProvingSchemeOptions",
+                    "description": "The supported Halo2 proving schemes.",
+                    "enum": [
+                        "shplonk"
+                    ],
+                    "type": "string"
+                },
+                "Halo2AxiomV022SindriManifest": {
+                    "title": "Sindri Manifest for Axiom v0.2.2 Halo2 Circuits",
+                    "description": "Sindri Manifest for Axiom v0.2.2 circuits built with the Halo2 framework.",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "title": "Circuit Name",
+                            "description": "The circuit name used to uniquely identify the circuit within your organization. Similar to a GitHub project name or a Docker image name.",
+                            "pattern": "^[-a-zA-Z0-9_]+$",
+                            "error_messages": {
+                                "regex": "`name` must be a valid slug."
+                            },
+                            "type": "string"
+                        },
+                        "circuitType": {
+                            "title": "Circuit Type",
+                            "description": "The (frontend) development framework that your circuit is written with.",
+                            "enum": [
+                                "halo2"
+                            ],
+                            "type": "string"
+                        },
+                        "className": {
+                            "title": "Circuit Class Name",
+                            "description": "The path to your circuit struct definition. (*e.g.* `my-package::my_file::MyCircuitStruct`).",
+                            "pattern": "^([A-Za-z_][A-Za-z0-9_]*::)+[A-Za-z_][A-Za-z0-9_]*$",
+                            "error_messages": {
+                                "regex": "`className` must be a valid and fully qualifed Rust path to a struct including the crate name."
+                            },
+                            "type": "string"
+                        },
+                        "degree": {
+                            "title": "Degree",
+                            "description": "Specifies that the circuit will have 2^degree rows.",
+                            "type": "integer"
+                        },
+                        "packageName": {
+                            "title": "Rust Package Name",
+                            "description": "The name of the Rust package containing your circuit.",
+                            "pattern": "^[a-z0-9_]+(?:-[a-z0-9_]+)*$",
+                            "error_messages": {
+                                "regex": "`packageName` must be a valid Rust crate name."
+                            },
+                            "type": "string"
+                        },
+                        "provingScheme": {
+                            "description": "The backend proving scheme.",
+                            "default": "shplonk",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/Halo2ProvingSchemeOptions"
+                                }
+                            ]
+                        },
+                        "halo2Version": {
+                            "title": "Halo2 Version",
+                            "description": "The Halo2 frontend that your circuit is written with.",
+                            "enum": [
+                                "axiom-v0.2.2"
+                            ],
+                            "type": "string"
+                        },
+                        "$schema": {
+                            "type": "string",
+                            "title": "Sindri Manifest JSON Schema URL",
+                            "description": "The URL pointing to a Sindri JSON Manifest schema definition.",
+                            "examples": [
+                                "https://sindri.app/api/v1/sindri-manifest-schema.json"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "circuitType",
+                        "className",
+                        "degree",
+                        "packageName",
+                        "halo2Version"
+                    ],
+                    "additionalProperties": false
+                },
+                "Halo2AxiomV030SindriManifest": {
+                    "title": "Sindri Manifest for Axiom v0.3.0 Halo2 Circuits",
+                    "description": "Sindri Manifest for Axiom v0.3.0 circuits built with the Halo2 framework.",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "title": "Circuit Name",
+                            "description": "The circuit name used to uniquely identify the circuit within your organization. Similar to a GitHub project name or a Docker image name.",
+                            "pattern": "^[-a-zA-Z0-9_]+$",
+                            "error_messages": {
+                                "regex": "`name` must be a valid slug."
+                            },
+                            "type": "string"
+                        },
+                        "circuitType": {
+                            "title": "Circuit Type",
+                            "description": "The (frontend) development framework that your circuit is written with.",
+                            "enum": [
+                                "halo2"
+                            ],
+                            "type": "string"
+                        },
+                        "className": {
+                            "title": "Circuit Class Name",
+                            "description": "The path to your circuit struct definition. (*e.g.* `my-package::my_file::MyCircuitStruct`).",
+                            "pattern": "^([A-Za-z_][A-Za-z0-9_]*::)+[A-Za-z_][A-Za-z0-9_]*$",
+                            "error_messages": {
+                                "regex": "`className` must be a valid and fully qualifed Rust path to a struct including the crate name."
+                            },
+                            "type": "string"
+                        },
+                        "degree": {
+                            "title": "Degree",
+                            "description": "Specifies that the circuit will have 2^degree rows.",
+                            "type": "integer"
+                        },
+                        "packageName": {
+                            "title": "Rust Package Name",
+                            "description": "The name of the Rust package containing your circuit.",
+                            "pattern": "^[a-z0-9_]+(?:-[a-z0-9_]+)*$",
+                            "error_messages": {
+                                "regex": "`packageName` must be a valid Rust crate name."
+                            },
+                            "type": "string"
+                        },
+                        "provingScheme": {
+                            "description": "The backend proving scheme.",
+                            "default": "shplonk",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/Halo2ProvingSchemeOptions"
+                                }
+                            ]
+                        },
+                        "halo2Version": {
+                            "title": "Halo2 Version",
+                            "description": "The Halo2 frontend that your circuit is written with.",
+                            "enum": [
+                                "axiom-v0.3.0"
+                            ],
+                            "type": "string"
+                        },
+                        "threadBuilder": {
+                            "title": "Thread Builder",
+                            "description": "The type of multi-threaded witness generator used. Choose GateThreadBuilder for simple circuits or RlcThreadBuilder for advanced applications that require sources of randomness.",
+                            "enum": [
+                                "GateThreadBuilder",
+                                "RlcThreadBuilder"
+                            ],
+                            "type": "string"
+                        },
+                        "$schema": {
+                            "type": "string",
+                            "title": "Sindri Manifest JSON Schema URL",
+                            "description": "The URL pointing to a Sindri JSON Manifest schema definition.",
+                            "examples": [
+                                "https://sindri.app/api/v1/sindri-manifest-schema.json"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "circuitType",
+                        "className",
+                        "degree",
+                        "packageName",
+                        "halo2Version",
+                        "threadBuilder"
+                    ],
+                    "additionalProperties": false
+                },
+                "NoirProvingSchemeOptions": {
+                    "title": "NoirProvingSchemeOptions",
+                    "description": "The supported Noir proving schemes.",
+                    "enum": [
+                        "barretenberg"
+                    ],
+                    "type": "string"
+                },
+                "NoirSindriManifest": {
+                    "title": "Sindri Manifest for Noir Circuits",
+                    "description": "Sindri Manifest for Noir circuits.",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "title": "Circuit Name",
+                            "description": "The circuit name used to uniquely identify the circuit within your organization. Similar to a GitHub project name or a Docker image name.",
+                            "pattern": "^[-a-zA-Z0-9_]+$",
+                            "error_messages": {
+                                "regex": "`name` must be a valid slug."
+                            },
+                            "type": "string"
+                        },
+                        "circuitType": {
+                            "title": "Circuit Type",
+                            "description": "The (frontend) development framework that your circuit is written with.",
+                            "enum": [
+                                "noir"
+                            ],
+                            "type": "string"
+                        },
+                        "provingScheme": {
+                            "description": "The backend proving scheme.",
+                            "default": "barretenberg",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/NoirProvingSchemeOptions"
+                                }
+                            ]
+                        },
+                        "$schema": {
+                            "type": "string",
+                            "title": "Sindri Manifest JSON Schema URL",
+                            "description": "The URL pointing to a Sindri JSON Manifest schema definition.",
+                            "examples": [
+                                "https://sindri.app/api/v1/sindri-manifest-schema.json"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "circuitType"
+                    ],
+                    "additionalProperties": false
+                }
+            }
+        },
+        "rawHeaders": [
+            "Access-Control-Allow-Origin",
+            "*",
+            "Content-Length",
+            "14963",
+            "Content-Type",
+            "application/schema+json",
+            "Date",
+            "Sat, 06 Jan 2024 05:42:14 GMT",
+            "Referrer-Policy",
+            "same-origin",
+            "Server",
+            "gunicorn",
+            "Vary",
+            "Cookie, origin",
+            "X-Content-Type-Options",
+            "nosniff",
+            "X-Frame-Options",
+            "SAMEORIGIN",
+            "Connection",
+            "close"
+        ],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://sindri.app:443",
+        "method": "get",
+        "path": "/api/v1/sindri-manifest-schema.json",
+        "body": "",
+        "status": 200,
+        "response": {
+            "$id": "https://sindri.app/api/v1/sindri-manifest-schema.json",
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "title": "SindriManifest",
+            "description": "Sindri Manifest file schema for `sindri.json` files.",
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/CircomSindriManifest"
+                },
+                {
+                    "$ref": "#/definitions/GnarkSindriManifest"
+                },
+                {
+                    "$ref": "#/definitions/Halo2AxiomV022SindriManifest"
+                },
+                {
+                    "$ref": "#/definitions/Halo2AxiomV030SindriManifest"
+                },
+                {
+                    "$ref": "#/definitions/NoirSindriManifest"
+                }
+            ],
+            "definitions": {
+                "CircomCurveOptions": {
+                    "title": "CircomCurveOptions",
+                    "description": "The supported Circom curves.",
+                    "enum": [
+                        "bn254"
+                    ],
+                    "type": "string"
+                },
+                "CircomProvingSchemeOptions": {
+                    "title": "CircomProvingSchemeOptions",
+                    "description": "The supported Circom proving schemes.",
+                    "enum": [
+                        "groth16"
+                    ],
+                    "type": "string"
+                },
+                "CircomWitnessCompilerOptions": {
+                    "title": "CircomWitnessCompilerOptions",
+                    "description": "The supported Circom witness compilers.",
+                    "enum": [
+                        "c++",
+                        "wasm"
+                    ],
+                    "type": "string"
+                },
+                "CircomSindriManifest": {
+                    "title": "Sindri Manifest for Circom Circuits",
+                    "description": "Sindri Manifest for Circom circuits.",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "title": "Circuit Name",
+                            "description": "The circuit name used to uniquely identify the circuit within your organization. Similar to a GitHub project name or a Docker image name.",
+                            "pattern": "^[-a-zA-Z0-9_]+$",
+                            "error_messages": {
+                                "regex": "`name` must be a valid slug."
+                            },
+                            "type": "string"
+                        },
+                        "circuitType": {
+                            "title": "Circuit Type",
+                            "description": "The (frontend) development framework that your circuit is written with.",
+                            "enum": [
+                                "circom"
+                            ],
+                            "type": "string"
+                        },
+                        "curve": {
+                            "title": "Proving Curve",
+                            "description": "The curve over which the proof is executed.",
+                            "default": "bn254",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/CircomCurveOptions"
+                                }
+                            ]
+                        },
+                        "provingScheme": {
+                            "description": "The backend proving scheme.",
+                            "default": "groth16",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/CircomProvingSchemeOptions"
+                                }
+                            ]
+                        },
+                        "witnessCompiler": {
+                            "description": "The circuit witness compiler.",
+                            "default": "c++",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/CircomWitnessCompilerOptions"
+                                }
+                            ]
+                        },
+                        "$schema": {
+                            "type": "string",
+                            "title": "Sindri Manifest JSON Schema URL",
+                            "description": "The URL pointing to a Sindri JSON Manifest schema definition.",
+                            "examples": [
+                                "https://sindri.app/api/v1/sindri-manifest-schema.json"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "circuitType"
+                    ],
+                    "additionalProperties": false
+                },
+                "GnarkCurveOptions": {
+                    "title": "GnarkCurveOptions",
+                    "description": "The supported Gnark curves.",
+                    "enum": [
+                        "bls12-377",
+                        "bls12-381",
+                        "bls24-315",
+                        "bn254",
+                        "bw6-633",
+                        "bw6-761"
+                    ],
+                    "type": "string"
+                },
+                "GnarkVersionOptions": {
+                    "title": "GnarkVersionOptions",
+                    "description": "The supported Gnark framework versions.",
+                    "enum": [
+                        "v0.8.1",
+                        "v0.9.0"
+                    ],
+                    "type": "string"
+                },
+                "GnarkProvingSchemeOptions": {
+                    "title": "GnarkProvingSchemeOptions",
+                    "description": "The supported Gnark proving schemes.",
+                    "enum": [
+                        "groth16"
+                    ],
+                    "type": "string"
+                },
+                "GnarkSindriManifest": {
+                    "title": "Sindri Manifest for Gnark Circuits",
+                    "description": "Sindri Manifest for Gnark circuits.",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "title": "Circuit Name",
+                            "description": "The circuit name used to uniquely identify the circuit within your organization. Similar to a GitHub project name or a Docker image name.",
+                            "pattern": "^[-a-zA-Z0-9_]+$",
+                            "error_messages": {
+                                "regex": "`name` must be a valid slug."
+                            },
+                            "type": "string"
+                        },
+                        "circuitStructName": {
+                            "title": "Circuit Struct Name",
+                            "description": "The name of the Go struct which defines your circuit inputs.",
+                            "pattern": "^[A-Z][A-Za-z0-9_]*$",
+                            "error_messages": {
+                                "regex": "`circuitStructName` must be a valid Go exported struct name."
+                            },
+                            "type": "string"
+                        },
+                        "circuitType": {
+                            "title": "Circuit Type",
+                            "description": "The (frontend) development framework that your circuit is written with.",
+                            "enum": [
+                                "gnark"
+                            ],
+                            "type": "string"
+                        },
+                        "curve": {
+                            "title": "Proving Curve",
+                            "description": "The curve over which the proof is executed.",
+                            "default": "bn254",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/GnarkCurveOptions"
+                                }
+                            ]
+                        },
+                        "gnarkVersion": {
+                            "description": "The version of the Gnark framework that your circuit uses.",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/GnarkVersionOptions"
+                                }
+                            ]
+                        },
+                        "packageName": {
+                            "title": "Go Package Name",
+                            "description": "The name of the Go package containing your circuit definition.",
+                            "pattern": "^[a-z][a-z0-9]*$",
+                            "error_messages": {
+                                "regex": "`packageName` must be a valid Go package name."
+                            },
+                            "type": "string"
+                        },
+                        "provingScheme": {
+                            "description": "The backend proving scheme.",
+                            "default": "groth16",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/GnarkProvingSchemeOptions"
+                                }
+                            ]
+                        },
+                        "$schema": {
+                            "type": "string",
+                            "title": "Sindri Manifest JSON Schema URL",
+                            "description": "The URL pointing to a Sindri JSON Manifest schema definition.",
+                            "examples": [
+                                "https://sindri.app/api/v1/sindri-manifest-schema.json"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "circuitStructName",
+                        "circuitType",
+                        "gnarkVersion",
+                        "packageName"
+                    ],
+                    "additionalProperties": false
+                },
+                "Halo2ProvingSchemeOptions": {
+                    "title": "Halo2ProvingSchemeOptions",
+                    "description": "The supported Halo2 proving schemes.",
+                    "enum": [
+                        "shplonk"
+                    ],
+                    "type": "string"
+                },
+                "Halo2AxiomV022SindriManifest": {
+                    "title": "Sindri Manifest for Axiom v0.2.2 Halo2 Circuits",
+                    "description": "Sindri Manifest for Axiom v0.2.2 circuits built with the Halo2 framework.",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "title": "Circuit Name",
+                            "description": "The circuit name used to uniquely identify the circuit within your organization. Similar to a GitHub project name or a Docker image name.",
+                            "pattern": "^[-a-zA-Z0-9_]+$",
+                            "error_messages": {
+                                "regex": "`name` must be a valid slug."
+                            },
+                            "type": "string"
+                        },
+                        "circuitType": {
+                            "title": "Circuit Type",
+                            "description": "The (frontend) development framework that your circuit is written with.",
+                            "enum": [
+                                "halo2"
+                            ],
+                            "type": "string"
+                        },
+                        "className": {
+                            "title": "Circuit Class Name",
+                            "description": "The path to your circuit struct definition. (*e.g.* `my-package::my_file::MyCircuitStruct`).",
+                            "pattern": "^([A-Za-z_][A-Za-z0-9_]*::)+[A-Za-z_][A-Za-z0-9_]*$",
+                            "error_messages": {
+                                "regex": "`className` must be a valid and fully qualifed Rust path to a struct including the crate name."
+                            },
+                            "type": "string"
+                        },
+                        "degree": {
+                            "title": "Degree",
+                            "description": "Specifies that the circuit will have 2^degree rows.",
+                            "type": "integer"
+                        },
+                        "packageName": {
+                            "title": "Rust Package Name",
+                            "description": "The name of the Rust package containing your circuit.",
+                            "pattern": "^[a-z0-9_]+(?:-[a-z0-9_]+)*$",
+                            "error_messages": {
+                                "regex": "`packageName` must be a valid Rust crate name."
+                            },
+                            "type": "string"
+                        },
+                        "provingScheme": {
+                            "description": "The backend proving scheme.",
+                            "default": "shplonk",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/Halo2ProvingSchemeOptions"
+                                }
+                            ]
+                        },
+                        "halo2Version": {
+                            "title": "Halo2 Version",
+                            "description": "The Halo2 frontend that your circuit is written with.",
+                            "enum": [
+                                "axiom-v0.2.2"
+                            ],
+                            "type": "string"
+                        },
+                        "$schema": {
+                            "type": "string",
+                            "title": "Sindri Manifest JSON Schema URL",
+                            "description": "The URL pointing to a Sindri JSON Manifest schema definition.",
+                            "examples": [
+                                "https://sindri.app/api/v1/sindri-manifest-schema.json"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "circuitType",
+                        "className",
+                        "degree",
+                        "packageName",
+                        "halo2Version"
+                    ],
+                    "additionalProperties": false
+                },
+                "Halo2AxiomV030SindriManifest": {
+                    "title": "Sindri Manifest for Axiom v0.3.0 Halo2 Circuits",
+                    "description": "Sindri Manifest for Axiom v0.3.0 circuits built with the Halo2 framework.",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "title": "Circuit Name",
+                            "description": "The circuit name used to uniquely identify the circuit within your organization. Similar to a GitHub project name or a Docker image name.",
+                            "pattern": "^[-a-zA-Z0-9_]+$",
+                            "error_messages": {
+                                "regex": "`name` must be a valid slug."
+                            },
+                            "type": "string"
+                        },
+                        "circuitType": {
+                            "title": "Circuit Type",
+                            "description": "The (frontend) development framework that your circuit is written with.",
+                            "enum": [
+                                "halo2"
+                            ],
+                            "type": "string"
+                        },
+                        "className": {
+                            "title": "Circuit Class Name",
+                            "description": "The path to your circuit struct definition. (*e.g.* `my-package::my_file::MyCircuitStruct`).",
+                            "pattern": "^([A-Za-z_][A-Za-z0-9_]*::)+[A-Za-z_][A-Za-z0-9_]*$",
+                            "error_messages": {
+                                "regex": "`className` must be a valid and fully qualifed Rust path to a struct including the crate name."
+                            },
+                            "type": "string"
+                        },
+                        "degree": {
+                            "title": "Degree",
+                            "description": "Specifies that the circuit will have 2^degree rows.",
+                            "type": "integer"
+                        },
+                        "packageName": {
+                            "title": "Rust Package Name",
+                            "description": "The name of the Rust package containing your circuit.",
+                            "pattern": "^[a-z0-9_]+(?:-[a-z0-9_]+)*$",
+                            "error_messages": {
+                                "regex": "`packageName` must be a valid Rust crate name."
+                            },
+                            "type": "string"
+                        },
+                        "provingScheme": {
+                            "description": "The backend proving scheme.",
+                            "default": "shplonk",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/Halo2ProvingSchemeOptions"
+                                }
+                            ]
+                        },
+                        "halo2Version": {
+                            "title": "Halo2 Version",
+                            "description": "The Halo2 frontend that your circuit is written with.",
+                            "enum": [
+                                "axiom-v0.3.0"
+                            ],
+                            "type": "string"
+                        },
+                        "threadBuilder": {
+                            "title": "Thread Builder",
+                            "description": "The type of multi-threaded witness generator used. Choose GateThreadBuilder for simple circuits or RlcThreadBuilder for advanced applications that require sources of randomness.",
+                            "enum": [
+                                "GateThreadBuilder",
+                                "RlcThreadBuilder"
+                            ],
+                            "type": "string"
+                        },
+                        "$schema": {
+                            "type": "string",
+                            "title": "Sindri Manifest JSON Schema URL",
+                            "description": "The URL pointing to a Sindri JSON Manifest schema definition.",
+                            "examples": [
+                                "https://sindri.app/api/v1/sindri-manifest-schema.json"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "circuitType",
+                        "className",
+                        "degree",
+                        "packageName",
+                        "halo2Version",
+                        "threadBuilder"
+                    ],
+                    "additionalProperties": false
+                },
+                "NoirProvingSchemeOptions": {
+                    "title": "NoirProvingSchemeOptions",
+                    "description": "The supported Noir proving schemes.",
+                    "enum": [
+                        "barretenberg"
+                    ],
+                    "type": "string"
+                },
+                "NoirSindriManifest": {
+                    "title": "Sindri Manifest for Noir Circuits",
+                    "description": "Sindri Manifest for Noir circuits.",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "title": "Circuit Name",
+                            "description": "The circuit name used to uniquely identify the circuit within your organization. Similar to a GitHub project name or a Docker image name.",
+                            "pattern": "^[-a-zA-Z0-9_]+$",
+                            "error_messages": {
+                                "regex": "`name` must be a valid slug."
+                            },
+                            "type": "string"
+                        },
+                        "circuitType": {
+                            "title": "Circuit Type",
+                            "description": "The (frontend) development framework that your circuit is written with.",
+                            "enum": [
+                                "noir"
+                            ],
+                            "type": "string"
+                        },
+                        "provingScheme": {
+                            "description": "The backend proving scheme.",
+                            "default": "barretenberg",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/NoirProvingSchemeOptions"
+                                }
+                            ]
+                        },
+                        "$schema": {
+                            "type": "string",
+                            "title": "Sindri Manifest JSON Schema URL",
+                            "description": "The URL pointing to a Sindri JSON Manifest schema definition.",
+                            "examples": [
+                                "https://sindri.app/api/v1/sindri-manifest-schema.json"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "circuitType"
+                    ],
+                    "additionalProperties": false
+                }
+            }
+        },
+        "rawHeaders": [
+            "Access-Control-Allow-Origin",
+            "*",
+            "Content-Length",
+            "14963",
+            "Content-Type",
+            "application/schema+json",
+            "Date",
+            "Sat, 06 Jan 2024 05:42:14 GMT",
+            "Referrer-Policy",
+            "same-origin",
+            "Server",
+            "gunicorn",
+            "Vary",
+            "Cookie, origin",
+            "X-Content-Type-Options",
+            "nosniff",
+            "X-Frame-Options",
+            "SAMEORIGIN",
+            "Connection",
+            "close"
+        ],
+        "responseIsBinary": false
+    }
+]

--- a/test/browser/main.test.ts
+++ b/test/browser/main.test.ts
@@ -15,14 +15,14 @@ test("should get Sindri manifest schema JSON", async (t) => {
   t.true(schema?.title?.includes("Sindri"));
 });
 
-test("2 should get Sindri manifest schema JSON", async (t) => {
+test("should get Sindri manifest schema JSON (number 2)", async (t) => {
   const schema = await t.context.page.evaluate(async () =>
     sindri.getSindriManifestSchema(),
   );
   t.true(schema?.title?.includes("Sindri"));
 });
 
-test("3 should get Sindri manifest schema JSON", async (t) => {
+test("should get robots.txt", async (t) => {
   try {
     await t.context.page.goto("https://sindri.app/robots.txt", { timeout: 5 });
   } catch (error) {}

--- a/test/browser/main.test.ts
+++ b/test/browser/main.test.ts
@@ -1,5 +1,4 @@
-import test from "ava";
-import withPage from "./withPage";
+import { test, usePage } from "./usePage";
 
 import sindriLibrary from "lib";
 
@@ -7,9 +6,25 @@ import sindriLibrary from "lib";
 type SindriLibrary = typeof sindriLibrary;
 declare const sindri: SindriLibrary;
 
-test("should get Sindri manifest schema JSON", withPage, async (t, page) => {
-  const schema = await page.evaluate(async () =>
+usePage();
+
+test("should get Sindri manifest schema JSON", async (t) => {
+  const schema = await t.context.page.evaluate(async () =>
     sindri.getSindriManifestSchema(),
   );
   t.true(schema?.title?.includes("Sindri"));
+});
+
+test("2 should get Sindri manifest schema JSON", async (t) => {
+  const schema = await t.context.page.evaluate(async () =>
+    sindri.getSindriManifestSchema(),
+  );
+  t.true(schema?.title?.includes("Sindri"));
+});
+
+test("3 should get Sindri manifest schema JSON", async (t) => {
+  try {
+    await t.context.page.goto("https://sindri.app/robots.txt", { timeout: 5 });
+  } catch (error) {}
+  t.true(true);
 });

--- a/test/browser/main.test.ts
+++ b/test/browser/main.test.ts
@@ -25,6 +25,8 @@ test("should get Sindri manifest schema JSON (number 2)", async (t) => {
 test("should get robots.txt", async (t) => {
   try {
     await t.context.page.goto("https://sindri.app/robots.txt", { timeout: 5 });
-  } catch (error) {}
+  } catch (error) {
+    /* ignore timeouts */
+  }
   t.true(true);
 });

--- a/test/browser/usePage.ts
+++ b/test/browser/usePage.ts
@@ -59,7 +59,7 @@ export const usePage = async () => {
     nock.disableNetConnect();
     nock.enableNetConnect("sindri.app");
     nockBack.setMode("lockdown");
-    console.log("Fixture location:", nodeBack.fixtures, fixtureFilename);
+    console.log("Fixture location:", nockBack.fixtures, fixtureFilename);
     const { nockDone } = await nockBack(fixtureFilename);
     t.context.nockDone = nockDone;
   });

--- a/test/browser/usePage.ts
+++ b/test/browser/usePage.ts
@@ -1,0 +1,95 @@
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+import testWithoutContext, { type ExecutionContext, type TestFn } from "ava";
+import nock, { back as nockBack } from "nock";
+import useNockWithWrongTypes from "nock-puppeteer";
+import puppeteer, {
+  type Browser,
+  type Page,
+  type ResourceType,
+} from "puppeteer";
+
+// Fix the types on `useNock`.
+const useNock = useNockWithWrongTypes as (
+  page: Page,
+  allowedHosts: string[],
+  supportedResourceTypes?: ResourceType[],
+) => Promise<void>;
+
+// Add the context to the test function type.
+export const test = testWithoutContext as TestFn<{
+  browser: Browser;
+  nockDone: () => void;
+  page: Page;
+}>;
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export const usePage = async () => {
+  // Prepare the nock fixture paths.
+  const testPath = test.meta.file.replace(/^file:/, "");
+  nockBack.fixtures = path.join(path.dirname(testPath), "fixtures");
+  const testFilenamePrefix = path.basename(testPath);
+  const fixtureFilename = `${testFilenamePrefix}.json`;
+
+  // Find the location of the Sindri IIFE script.
+  const sindriScriptPath = path.join(
+    __dirname,
+    "..",
+    "..",
+    "dist",
+    "lib",
+    "browser",
+    "sindri.iife.js",
+  );
+  if (!fs.existsSync(sindriScriptPath)) {
+    throw new Error(`Expected IIFE build to exist at "${sindriScriptPath}".`);
+  }
+
+  test.before(async (t: ExecutionContext) => {
+    // Launch the Puppeteer browser without any nock interference.
+    nockBack.setMode("wild");
+    nock.enableNetConnect();
+    t.context.browser = await puppeteer.launch({ headless: "new" });
+
+    // Start recording, and only allow connections to `sindri.app`.
+    nock.disableNetConnect();
+    nock.enableNetConnect("sindri.app");
+    nockBack.setMode("lockdown");
+    const { nockDone } = await nockBack(fixtureFilename);
+    t.context.nockDone = nockDone;
+  });
+
+  test.beforeEach(async (t: ExecutionContext) => {
+    // Open a new browser tab for the test, inject the script tag, and route requests through nock.
+    t.context.page = await t.context.browser.newPage();
+    await t.context.page.addScriptTag({
+      path: sindriScriptPath,
+    });
+    useNock(t.context.page, ["https://sindri.app"]);
+  });
+
+  test.afterEach.always(async (t: ExecutionContext) => {
+    // Close the browser tab after each test.
+    if (t.context.page) {
+      await t.context.page.close();
+    }
+  });
+
+  test.after.always(async (t: ExecutionContext) => {
+    // Close the browser after all tests.
+    if (t.context.browser) {
+      await t.context.browser.close();
+    }
+
+    // Stop recording and re-enable all network connections.
+    if (t.context.nockDone) {
+      t.context.nockDone();
+    }
+    nock.enableNetConnect();
+    nockBack.setMode("wild");
+  });
+};

--- a/test/browser/usePage.ts
+++ b/test/browser/usePage.ts
@@ -60,7 +60,6 @@ export const usePage = async () => {
     nock.disableNetConnect();
     nock.enableNetConnect("sindri.app");
     nockBack.setMode("lockdown");
-    console.log("Fixture location:", nockBack.fixtures, fixtureFilename);
     const { nockDone } = await nockBack(fixtureFilename);
     t.context.nockDone = nockDone;
   });

--- a/test/browser/usePage.ts
+++ b/test/browser/usePage.ts
@@ -59,6 +59,7 @@ export const usePage = async () => {
     nock.disableNetConnect();
     nock.enableNetConnect("sindri.app");
     nockBack.setMode("lockdown");
+    console.log("Fixture location:", nodeBack.fixtures, fixtureFilename);
     const { nockDone } = await nockBack(fixtureFilename);
     t.context.nockDone = nockDone;
   });

--- a/test/browser/usePage.ts
+++ b/test/browser/usePage.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
 import path from "path";
+import process from "process";
 import { fileURLToPath } from "url";
 
 import testWithoutContext, { type ExecutionContext, type TestFn } from "ava";
@@ -59,7 +60,7 @@ export const usePage = async () => {
     // Start recording, and only allow connections to `sindri.app`.
     nock.disableNetConnect();
     nock.enableNetConnect("sindri.app");
-    nockBack.setMode("lockdown");
+    nockBack.setMode(process.env.NOCK_BACK_MODE ?? "lockdown");
     const { nockDone } = await nockBack(fixtureFilename);
     t.context.nockDone = nockDone;
   });

--- a/test/browser/usePage.ts
+++ b/test/browser/usePage.ts
@@ -4,7 +4,7 @@ import process from "process";
 import { fileURLToPath } from "url";
 
 import testWithoutContext, { type ExecutionContext, type TestFn } from "ava";
-import nock, { back as nockBack } from "nock";
+import nock, { back as nockBack, type BackMode } from "nock";
 import useNockWithWrongTypes from "nock-puppeteer";
 import puppeteer, {
   type Browser,
@@ -60,7 +60,7 @@ export const usePage = async () => {
     // Start recording, and only allow connections to `sindri.app`.
     nock.disableNetConnect();
     nock.enableNetConnect("sindri.app");
-    nockBack.setMode(process.env.NOCK_BACK_MODE ?? "lockdown");
+    nockBack.setMode((process.env.NOCK_BACK_MODE ?? "lockdown") as BackMode);
     const { nockDone } = await nockBack(fixtureFilename);
     t.context.nockDone = nockDone;
   });

--- a/test/browser/usePage.ts
+++ b/test/browser/usePage.ts
@@ -5,15 +5,15 @@ import { fileURLToPath } from "url";
 
 import testWithoutContext, { type ExecutionContext, type TestFn } from "ava";
 import nock, { back as nockBack, type BackMode } from "nock";
-import useNockWithWrongTypes from "nock-puppeteer";
+import useNockPuppeteerWithWrongTypes from "nock-puppeteer";
 import puppeteer, {
   type Browser,
   type Page,
   type ResourceType,
 } from "puppeteer";
 
-// Fix the types on `useNock`.
-const useNock = useNockWithWrongTypes as (
+// Fix the types on `useNockPuppeteer`.
+const useNockPuppeteer = useNockPuppeteerWithWrongTypes as (
   page: Page,
   allowedHosts: string[],
   supportedResourceTypes?: ResourceType[],
@@ -71,7 +71,7 @@ export const usePage = async () => {
     await t.context.page.addScriptTag({
       path: sindriScriptPath,
     });
-    useNock(t.context.page, ["https://sindri.app"]);
+    useNockPuppeteer(t.context.page, ["https://sindri.app"]);
   });
 
   test.afterEach.always(async (t: ExecutionContext<Context>) => {

--- a/test/lib/fixtures/testConfiguration.test.ts.json
+++ b/test/lib/fixtures/testConfiguration.test.ts.json
@@ -1,0 +1,986 @@
+[
+    {
+        "scope": "https://sindri.app:443",
+        "method": "GET",
+        "path": "/api/v1/sindri-manifest-schema.json",
+        "body": "",
+        "status": 200,
+        "response": {
+            "$id": "https://sindri.app/api/v1/sindri-manifest-schema.json",
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "title": "SindriManifest",
+            "description": "Sindri Manifest file schema for `sindri.json` files.",
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/CircomSindriManifest"
+                },
+                {
+                    "$ref": "#/definitions/GnarkSindriManifest"
+                },
+                {
+                    "$ref": "#/definitions/Halo2AxiomV022SindriManifest"
+                },
+                {
+                    "$ref": "#/definitions/Halo2AxiomV030SindriManifest"
+                },
+                {
+                    "$ref": "#/definitions/NoirSindriManifest"
+                }
+            ],
+            "definitions": {
+                "CircomCurveOptions": {
+                    "title": "CircomCurveOptions",
+                    "description": "The supported Circom curves.",
+                    "enum": [
+                        "bn254"
+                    ],
+                    "type": "string"
+                },
+                "CircomProvingSchemeOptions": {
+                    "title": "CircomProvingSchemeOptions",
+                    "description": "The supported Circom proving schemes.",
+                    "enum": [
+                        "groth16"
+                    ],
+                    "type": "string"
+                },
+                "CircomWitnessCompilerOptions": {
+                    "title": "CircomWitnessCompilerOptions",
+                    "description": "The supported Circom witness compilers.",
+                    "enum": [
+                        "c++",
+                        "wasm"
+                    ],
+                    "type": "string"
+                },
+                "CircomSindriManifest": {
+                    "title": "Sindri Manifest for Circom Circuits",
+                    "description": "Sindri Manifest for Circom circuits.",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "title": "Circuit Name",
+                            "description": "The circuit name used to uniquely identify the circuit within your organization. Similar to a GitHub project name or a Docker image name.",
+                            "pattern": "^[-a-zA-Z0-9_]+$",
+                            "error_messages": {
+                                "regex": "`name` must be a valid slug."
+                            },
+                            "type": "string"
+                        },
+                        "circuitType": {
+                            "title": "Circuit Type",
+                            "description": "The (frontend) development framework that your circuit is written with.",
+                            "enum": [
+                                "circom"
+                            ],
+                            "type": "string"
+                        },
+                        "curve": {
+                            "title": "Proving Curve",
+                            "description": "The curve over which the proof is executed.",
+                            "default": "bn254",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/CircomCurveOptions"
+                                }
+                            ]
+                        },
+                        "provingScheme": {
+                            "description": "The backend proving scheme.",
+                            "default": "groth16",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/CircomProvingSchemeOptions"
+                                }
+                            ]
+                        },
+                        "witnessCompiler": {
+                            "description": "The circuit witness compiler.",
+                            "default": "c++",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/CircomWitnessCompilerOptions"
+                                }
+                            ]
+                        },
+                        "$schema": {
+                            "type": "string",
+                            "title": "Sindri Manifest JSON Schema URL",
+                            "description": "The URL pointing to a Sindri JSON Manifest schema definition.",
+                            "examples": [
+                                "https://sindri.app/api/v1/sindri-manifest-schema.json"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "circuitType"
+                    ],
+                    "additionalProperties": false
+                },
+                "GnarkCurveOptions": {
+                    "title": "GnarkCurveOptions",
+                    "description": "The supported Gnark curves.",
+                    "enum": [
+                        "bls12-377",
+                        "bls12-381",
+                        "bls24-315",
+                        "bn254",
+                        "bw6-633",
+                        "bw6-761"
+                    ],
+                    "type": "string"
+                },
+                "GnarkVersionOptions": {
+                    "title": "GnarkVersionOptions",
+                    "description": "The supported Gnark framework versions.",
+                    "enum": [
+                        "v0.8.1",
+                        "v0.9.0"
+                    ],
+                    "type": "string"
+                },
+                "GnarkProvingSchemeOptions": {
+                    "title": "GnarkProvingSchemeOptions",
+                    "description": "The supported Gnark proving schemes.",
+                    "enum": [
+                        "groth16"
+                    ],
+                    "type": "string"
+                },
+                "GnarkSindriManifest": {
+                    "title": "Sindri Manifest for Gnark Circuits",
+                    "description": "Sindri Manifest for Gnark circuits.",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "title": "Circuit Name",
+                            "description": "The circuit name used to uniquely identify the circuit within your organization. Similar to a GitHub project name or a Docker image name.",
+                            "pattern": "^[-a-zA-Z0-9_]+$",
+                            "error_messages": {
+                                "regex": "`name` must be a valid slug."
+                            },
+                            "type": "string"
+                        },
+                        "circuitStructName": {
+                            "title": "Circuit Struct Name",
+                            "description": "The name of the Go struct which defines your circuit inputs.",
+                            "pattern": "^[A-Z][A-Za-z0-9_]*$",
+                            "error_messages": {
+                                "regex": "`circuitStructName` must be a valid Go exported struct name."
+                            },
+                            "type": "string"
+                        },
+                        "circuitType": {
+                            "title": "Circuit Type",
+                            "description": "The (frontend) development framework that your circuit is written with.",
+                            "enum": [
+                                "gnark"
+                            ],
+                            "type": "string"
+                        },
+                        "curve": {
+                            "title": "Proving Curve",
+                            "description": "The curve over which the proof is executed.",
+                            "default": "bn254",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/GnarkCurveOptions"
+                                }
+                            ]
+                        },
+                        "gnarkVersion": {
+                            "description": "The version of the Gnark framework that your circuit uses.",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/GnarkVersionOptions"
+                                }
+                            ]
+                        },
+                        "packageName": {
+                            "title": "Go Package Name",
+                            "description": "The name of the Go package containing your circuit definition.",
+                            "pattern": "^[a-z][a-z0-9]*$",
+                            "error_messages": {
+                                "regex": "`packageName` must be a valid Go package name."
+                            },
+                            "type": "string"
+                        },
+                        "provingScheme": {
+                            "description": "The backend proving scheme.",
+                            "default": "groth16",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/GnarkProvingSchemeOptions"
+                                }
+                            ]
+                        },
+                        "$schema": {
+                            "type": "string",
+                            "title": "Sindri Manifest JSON Schema URL",
+                            "description": "The URL pointing to a Sindri JSON Manifest schema definition.",
+                            "examples": [
+                                "https://sindri.app/api/v1/sindri-manifest-schema.json"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "circuitStructName",
+                        "circuitType",
+                        "gnarkVersion",
+                        "packageName"
+                    ],
+                    "additionalProperties": false
+                },
+                "Halo2ProvingSchemeOptions": {
+                    "title": "Halo2ProvingSchemeOptions",
+                    "description": "The supported Halo2 proving schemes.",
+                    "enum": [
+                        "shplonk"
+                    ],
+                    "type": "string"
+                },
+                "Halo2AxiomV022SindriManifest": {
+                    "title": "Sindri Manifest for Axiom v0.2.2 Halo2 Circuits",
+                    "description": "Sindri Manifest for Axiom v0.2.2 circuits built with the Halo2 framework.",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "title": "Circuit Name",
+                            "description": "The circuit name used to uniquely identify the circuit within your organization. Similar to a GitHub project name or a Docker image name.",
+                            "pattern": "^[-a-zA-Z0-9_]+$",
+                            "error_messages": {
+                                "regex": "`name` must be a valid slug."
+                            },
+                            "type": "string"
+                        },
+                        "circuitType": {
+                            "title": "Circuit Type",
+                            "description": "The (frontend) development framework that your circuit is written with.",
+                            "enum": [
+                                "halo2"
+                            ],
+                            "type": "string"
+                        },
+                        "className": {
+                            "title": "Circuit Class Name",
+                            "description": "The path to your circuit struct definition. (*e.g.* `my-package::my_file::MyCircuitStruct`).",
+                            "pattern": "^([A-Za-z_][A-Za-z0-9_]*::)+[A-Za-z_][A-Za-z0-9_]*$",
+                            "error_messages": {
+                                "regex": "`className` must be a valid and fully qualifed Rust path to a struct including the crate name."
+                            },
+                            "type": "string"
+                        },
+                        "degree": {
+                            "title": "Degree",
+                            "description": "Specifies that the circuit will have 2^degree rows.",
+                            "type": "integer"
+                        },
+                        "packageName": {
+                            "title": "Rust Package Name",
+                            "description": "The name of the Rust package containing your circuit.",
+                            "pattern": "^[a-z0-9_]+(?:-[a-z0-9_]+)*$",
+                            "error_messages": {
+                                "regex": "`packageName` must be a valid Rust crate name."
+                            },
+                            "type": "string"
+                        },
+                        "provingScheme": {
+                            "description": "The backend proving scheme.",
+                            "default": "shplonk",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/Halo2ProvingSchemeOptions"
+                                }
+                            ]
+                        },
+                        "halo2Version": {
+                            "title": "Halo2 Version",
+                            "description": "The Halo2 frontend that your circuit is written with.",
+                            "enum": [
+                                "axiom-v0.2.2"
+                            ],
+                            "type": "string"
+                        },
+                        "$schema": {
+                            "type": "string",
+                            "title": "Sindri Manifest JSON Schema URL",
+                            "description": "The URL pointing to a Sindri JSON Manifest schema definition.",
+                            "examples": [
+                                "https://sindri.app/api/v1/sindri-manifest-schema.json"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "circuitType",
+                        "className",
+                        "degree",
+                        "packageName",
+                        "halo2Version"
+                    ],
+                    "additionalProperties": false
+                },
+                "Halo2AxiomV030SindriManifest": {
+                    "title": "Sindri Manifest for Axiom v0.3.0 Halo2 Circuits",
+                    "description": "Sindri Manifest for Axiom v0.3.0 circuits built with the Halo2 framework.",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "title": "Circuit Name",
+                            "description": "The circuit name used to uniquely identify the circuit within your organization. Similar to a GitHub project name or a Docker image name.",
+                            "pattern": "^[-a-zA-Z0-9_]+$",
+                            "error_messages": {
+                                "regex": "`name` must be a valid slug."
+                            },
+                            "type": "string"
+                        },
+                        "circuitType": {
+                            "title": "Circuit Type",
+                            "description": "The (frontend) development framework that your circuit is written with.",
+                            "enum": [
+                                "halo2"
+                            ],
+                            "type": "string"
+                        },
+                        "className": {
+                            "title": "Circuit Class Name",
+                            "description": "The path to your circuit struct definition. (*e.g.* `my-package::my_file::MyCircuitStruct`).",
+                            "pattern": "^([A-Za-z_][A-Za-z0-9_]*::)+[A-Za-z_][A-Za-z0-9_]*$",
+                            "error_messages": {
+                                "regex": "`className` must be a valid and fully qualifed Rust path to a struct including the crate name."
+                            },
+                            "type": "string"
+                        },
+                        "degree": {
+                            "title": "Degree",
+                            "description": "Specifies that the circuit will have 2^degree rows.",
+                            "type": "integer"
+                        },
+                        "packageName": {
+                            "title": "Rust Package Name",
+                            "description": "The name of the Rust package containing your circuit.",
+                            "pattern": "^[a-z0-9_]+(?:-[a-z0-9_]+)*$",
+                            "error_messages": {
+                                "regex": "`packageName` must be a valid Rust crate name."
+                            },
+                            "type": "string"
+                        },
+                        "provingScheme": {
+                            "description": "The backend proving scheme.",
+                            "default": "shplonk",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/Halo2ProvingSchemeOptions"
+                                }
+                            ]
+                        },
+                        "halo2Version": {
+                            "title": "Halo2 Version",
+                            "description": "The Halo2 frontend that your circuit is written with.",
+                            "enum": [
+                                "axiom-v0.3.0"
+                            ],
+                            "type": "string"
+                        },
+                        "threadBuilder": {
+                            "title": "Thread Builder",
+                            "description": "The type of multi-threaded witness generator used. Choose GateThreadBuilder for simple circuits or RlcThreadBuilder for advanced applications that require sources of randomness.",
+                            "enum": [
+                                "GateThreadBuilder",
+                                "RlcThreadBuilder"
+                            ],
+                            "type": "string"
+                        },
+                        "$schema": {
+                            "type": "string",
+                            "title": "Sindri Manifest JSON Schema URL",
+                            "description": "The URL pointing to a Sindri JSON Manifest schema definition.",
+                            "examples": [
+                                "https://sindri.app/api/v1/sindri-manifest-schema.json"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "circuitType",
+                        "className",
+                        "degree",
+                        "packageName",
+                        "halo2Version",
+                        "threadBuilder"
+                    ],
+                    "additionalProperties": false
+                },
+                "NoirProvingSchemeOptions": {
+                    "title": "NoirProvingSchemeOptions",
+                    "description": "The supported Noir proving schemes.",
+                    "enum": [
+                        "barretenberg"
+                    ],
+                    "type": "string"
+                },
+                "NoirSindriManifest": {
+                    "title": "Sindri Manifest for Noir Circuits",
+                    "description": "Sindri Manifest for Noir circuits.",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "title": "Circuit Name",
+                            "description": "The circuit name used to uniquely identify the circuit within your organization. Similar to a GitHub project name or a Docker image name.",
+                            "pattern": "^[-a-zA-Z0-9_]+$",
+                            "error_messages": {
+                                "regex": "`name` must be a valid slug."
+                            },
+                            "type": "string"
+                        },
+                        "circuitType": {
+                            "title": "Circuit Type",
+                            "description": "The (frontend) development framework that your circuit is written with.",
+                            "enum": [
+                                "noir"
+                            ],
+                            "type": "string"
+                        },
+                        "provingScheme": {
+                            "description": "The backend proving scheme.",
+                            "default": "barretenberg",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/NoirProvingSchemeOptions"
+                                }
+                            ]
+                        },
+                        "$schema": {
+                            "type": "string",
+                            "title": "Sindri Manifest JSON Schema URL",
+                            "description": "The URL pointing to a Sindri JSON Manifest schema definition.",
+                            "examples": [
+                                "https://sindri.app/api/v1/sindri-manifest-schema.json"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "circuitType"
+                    ],
+                    "additionalProperties": false
+                }
+            }
+        },
+        "rawHeaders": [
+            "Content-Length",
+            "14963",
+            "Content-Type",
+            "application/schema+json",
+            "Date",
+            "Sat, 06 Jan 2024 20:38:40 GMT",
+            "Referrer-Policy",
+            "same-origin",
+            "Server",
+            "gunicorn",
+            "Vary",
+            "Cookie, origin",
+            "X-Content-Type-Options",
+            "nosniff",
+            "X-Frame-Options",
+            "SAMEORIGIN",
+            "Connection",
+            "close"
+        ],
+        "responseIsBinary": false
+    },
+    {
+        "scope": "https://sindri.app:443",
+        "method": "GET",
+        "path": "/api/v1/sindri-manifest-schema.json",
+        "body": "",
+        "status": 200,
+        "response": {
+            "$id": "https://sindri.app/api/v1/sindri-manifest-schema.json",
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "title": "SindriManifest",
+            "description": "Sindri Manifest file schema for `sindri.json` files.",
+            "anyOf": [
+                {
+                    "$ref": "#/definitions/CircomSindriManifest"
+                },
+                {
+                    "$ref": "#/definitions/GnarkSindriManifest"
+                },
+                {
+                    "$ref": "#/definitions/Halo2AxiomV022SindriManifest"
+                },
+                {
+                    "$ref": "#/definitions/Halo2AxiomV030SindriManifest"
+                },
+                {
+                    "$ref": "#/definitions/NoirSindriManifest"
+                }
+            ],
+            "definitions": {
+                "CircomCurveOptions": {
+                    "title": "CircomCurveOptions",
+                    "description": "The supported Circom curves.",
+                    "enum": [
+                        "bn254"
+                    ],
+                    "type": "string"
+                },
+                "CircomProvingSchemeOptions": {
+                    "title": "CircomProvingSchemeOptions",
+                    "description": "The supported Circom proving schemes.",
+                    "enum": [
+                        "groth16"
+                    ],
+                    "type": "string"
+                },
+                "CircomWitnessCompilerOptions": {
+                    "title": "CircomWitnessCompilerOptions",
+                    "description": "The supported Circom witness compilers.",
+                    "enum": [
+                        "c++",
+                        "wasm"
+                    ],
+                    "type": "string"
+                },
+                "CircomSindriManifest": {
+                    "title": "Sindri Manifest for Circom Circuits",
+                    "description": "Sindri Manifest for Circom circuits.",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "title": "Circuit Name",
+                            "description": "The circuit name used to uniquely identify the circuit within your organization. Similar to a GitHub project name or a Docker image name.",
+                            "pattern": "^[-a-zA-Z0-9_]+$",
+                            "error_messages": {
+                                "regex": "`name` must be a valid slug."
+                            },
+                            "type": "string"
+                        },
+                        "circuitType": {
+                            "title": "Circuit Type",
+                            "description": "The (frontend) development framework that your circuit is written with.",
+                            "enum": [
+                                "circom"
+                            ],
+                            "type": "string"
+                        },
+                        "curve": {
+                            "title": "Proving Curve",
+                            "description": "The curve over which the proof is executed.",
+                            "default": "bn254",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/CircomCurveOptions"
+                                }
+                            ]
+                        },
+                        "provingScheme": {
+                            "description": "The backend proving scheme.",
+                            "default": "groth16",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/CircomProvingSchemeOptions"
+                                }
+                            ]
+                        },
+                        "witnessCompiler": {
+                            "description": "The circuit witness compiler.",
+                            "default": "c++",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/CircomWitnessCompilerOptions"
+                                }
+                            ]
+                        },
+                        "$schema": {
+                            "type": "string",
+                            "title": "Sindri Manifest JSON Schema URL",
+                            "description": "The URL pointing to a Sindri JSON Manifest schema definition.",
+                            "examples": [
+                                "https://sindri.app/api/v1/sindri-manifest-schema.json"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "circuitType"
+                    ],
+                    "additionalProperties": false
+                },
+                "GnarkCurveOptions": {
+                    "title": "GnarkCurveOptions",
+                    "description": "The supported Gnark curves.",
+                    "enum": [
+                        "bls12-377",
+                        "bls12-381",
+                        "bls24-315",
+                        "bn254",
+                        "bw6-633",
+                        "bw6-761"
+                    ],
+                    "type": "string"
+                },
+                "GnarkVersionOptions": {
+                    "title": "GnarkVersionOptions",
+                    "description": "The supported Gnark framework versions.",
+                    "enum": [
+                        "v0.8.1",
+                        "v0.9.0"
+                    ],
+                    "type": "string"
+                },
+                "GnarkProvingSchemeOptions": {
+                    "title": "GnarkProvingSchemeOptions",
+                    "description": "The supported Gnark proving schemes.",
+                    "enum": [
+                        "groth16"
+                    ],
+                    "type": "string"
+                },
+                "GnarkSindriManifest": {
+                    "title": "Sindri Manifest for Gnark Circuits",
+                    "description": "Sindri Manifest for Gnark circuits.",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "title": "Circuit Name",
+                            "description": "The circuit name used to uniquely identify the circuit within your organization. Similar to a GitHub project name or a Docker image name.",
+                            "pattern": "^[-a-zA-Z0-9_]+$",
+                            "error_messages": {
+                                "regex": "`name` must be a valid slug."
+                            },
+                            "type": "string"
+                        },
+                        "circuitStructName": {
+                            "title": "Circuit Struct Name",
+                            "description": "The name of the Go struct which defines your circuit inputs.",
+                            "pattern": "^[A-Z][A-Za-z0-9_]*$",
+                            "error_messages": {
+                                "regex": "`circuitStructName` must be a valid Go exported struct name."
+                            },
+                            "type": "string"
+                        },
+                        "circuitType": {
+                            "title": "Circuit Type",
+                            "description": "The (frontend) development framework that your circuit is written with.",
+                            "enum": [
+                                "gnark"
+                            ],
+                            "type": "string"
+                        },
+                        "curve": {
+                            "title": "Proving Curve",
+                            "description": "The curve over which the proof is executed.",
+                            "default": "bn254",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/GnarkCurveOptions"
+                                }
+                            ]
+                        },
+                        "gnarkVersion": {
+                            "description": "The version of the Gnark framework that your circuit uses.",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/GnarkVersionOptions"
+                                }
+                            ]
+                        },
+                        "packageName": {
+                            "title": "Go Package Name",
+                            "description": "The name of the Go package containing your circuit definition.",
+                            "pattern": "^[a-z][a-z0-9]*$",
+                            "error_messages": {
+                                "regex": "`packageName` must be a valid Go package name."
+                            },
+                            "type": "string"
+                        },
+                        "provingScheme": {
+                            "description": "The backend proving scheme.",
+                            "default": "groth16",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/GnarkProvingSchemeOptions"
+                                }
+                            ]
+                        },
+                        "$schema": {
+                            "type": "string",
+                            "title": "Sindri Manifest JSON Schema URL",
+                            "description": "The URL pointing to a Sindri JSON Manifest schema definition.",
+                            "examples": [
+                                "https://sindri.app/api/v1/sindri-manifest-schema.json"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "circuitStructName",
+                        "circuitType",
+                        "gnarkVersion",
+                        "packageName"
+                    ],
+                    "additionalProperties": false
+                },
+                "Halo2ProvingSchemeOptions": {
+                    "title": "Halo2ProvingSchemeOptions",
+                    "description": "The supported Halo2 proving schemes.",
+                    "enum": [
+                        "shplonk"
+                    ],
+                    "type": "string"
+                },
+                "Halo2AxiomV022SindriManifest": {
+                    "title": "Sindri Manifest for Axiom v0.2.2 Halo2 Circuits",
+                    "description": "Sindri Manifest for Axiom v0.2.2 circuits built with the Halo2 framework.",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "title": "Circuit Name",
+                            "description": "The circuit name used to uniquely identify the circuit within your organization. Similar to a GitHub project name or a Docker image name.",
+                            "pattern": "^[-a-zA-Z0-9_]+$",
+                            "error_messages": {
+                                "regex": "`name` must be a valid slug."
+                            },
+                            "type": "string"
+                        },
+                        "circuitType": {
+                            "title": "Circuit Type",
+                            "description": "The (frontend) development framework that your circuit is written with.",
+                            "enum": [
+                                "halo2"
+                            ],
+                            "type": "string"
+                        },
+                        "className": {
+                            "title": "Circuit Class Name",
+                            "description": "The path to your circuit struct definition. (*e.g.* `my-package::my_file::MyCircuitStruct`).",
+                            "pattern": "^([A-Za-z_][A-Za-z0-9_]*::)+[A-Za-z_][A-Za-z0-9_]*$",
+                            "error_messages": {
+                                "regex": "`className` must be a valid and fully qualifed Rust path to a struct including the crate name."
+                            },
+                            "type": "string"
+                        },
+                        "degree": {
+                            "title": "Degree",
+                            "description": "Specifies that the circuit will have 2^degree rows.",
+                            "type": "integer"
+                        },
+                        "packageName": {
+                            "title": "Rust Package Name",
+                            "description": "The name of the Rust package containing your circuit.",
+                            "pattern": "^[a-z0-9_]+(?:-[a-z0-9_]+)*$",
+                            "error_messages": {
+                                "regex": "`packageName` must be a valid Rust crate name."
+                            },
+                            "type": "string"
+                        },
+                        "provingScheme": {
+                            "description": "The backend proving scheme.",
+                            "default": "shplonk",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/Halo2ProvingSchemeOptions"
+                                }
+                            ]
+                        },
+                        "halo2Version": {
+                            "title": "Halo2 Version",
+                            "description": "The Halo2 frontend that your circuit is written with.",
+                            "enum": [
+                                "axiom-v0.2.2"
+                            ],
+                            "type": "string"
+                        },
+                        "$schema": {
+                            "type": "string",
+                            "title": "Sindri Manifest JSON Schema URL",
+                            "description": "The URL pointing to a Sindri JSON Manifest schema definition.",
+                            "examples": [
+                                "https://sindri.app/api/v1/sindri-manifest-schema.json"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "circuitType",
+                        "className",
+                        "degree",
+                        "packageName",
+                        "halo2Version"
+                    ],
+                    "additionalProperties": false
+                },
+                "Halo2AxiomV030SindriManifest": {
+                    "title": "Sindri Manifest for Axiom v0.3.0 Halo2 Circuits",
+                    "description": "Sindri Manifest for Axiom v0.3.0 circuits built with the Halo2 framework.",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "title": "Circuit Name",
+                            "description": "The circuit name used to uniquely identify the circuit within your organization. Similar to a GitHub project name or a Docker image name.",
+                            "pattern": "^[-a-zA-Z0-9_]+$",
+                            "error_messages": {
+                                "regex": "`name` must be a valid slug."
+                            },
+                            "type": "string"
+                        },
+                        "circuitType": {
+                            "title": "Circuit Type",
+                            "description": "The (frontend) development framework that your circuit is written with.",
+                            "enum": [
+                                "halo2"
+                            ],
+                            "type": "string"
+                        },
+                        "className": {
+                            "title": "Circuit Class Name",
+                            "description": "The path to your circuit struct definition. (*e.g.* `my-package::my_file::MyCircuitStruct`).",
+                            "pattern": "^([A-Za-z_][A-Za-z0-9_]*::)+[A-Za-z_][A-Za-z0-9_]*$",
+                            "error_messages": {
+                                "regex": "`className` must be a valid and fully qualifed Rust path to a struct including the crate name."
+                            },
+                            "type": "string"
+                        },
+                        "degree": {
+                            "title": "Degree",
+                            "description": "Specifies that the circuit will have 2^degree rows.",
+                            "type": "integer"
+                        },
+                        "packageName": {
+                            "title": "Rust Package Name",
+                            "description": "The name of the Rust package containing your circuit.",
+                            "pattern": "^[a-z0-9_]+(?:-[a-z0-9_]+)*$",
+                            "error_messages": {
+                                "regex": "`packageName` must be a valid Rust crate name."
+                            },
+                            "type": "string"
+                        },
+                        "provingScheme": {
+                            "description": "The backend proving scheme.",
+                            "default": "shplonk",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/Halo2ProvingSchemeOptions"
+                                }
+                            ]
+                        },
+                        "halo2Version": {
+                            "title": "Halo2 Version",
+                            "description": "The Halo2 frontend that your circuit is written with.",
+                            "enum": [
+                                "axiom-v0.3.0"
+                            ],
+                            "type": "string"
+                        },
+                        "threadBuilder": {
+                            "title": "Thread Builder",
+                            "description": "The type of multi-threaded witness generator used. Choose GateThreadBuilder for simple circuits or RlcThreadBuilder for advanced applications that require sources of randomness.",
+                            "enum": [
+                                "GateThreadBuilder",
+                                "RlcThreadBuilder"
+                            ],
+                            "type": "string"
+                        },
+                        "$schema": {
+                            "type": "string",
+                            "title": "Sindri Manifest JSON Schema URL",
+                            "description": "The URL pointing to a Sindri JSON Manifest schema definition.",
+                            "examples": [
+                                "https://sindri.app/api/v1/sindri-manifest-schema.json"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "circuitType",
+                        "className",
+                        "degree",
+                        "packageName",
+                        "halo2Version",
+                        "threadBuilder"
+                    ],
+                    "additionalProperties": false
+                },
+                "NoirProvingSchemeOptions": {
+                    "title": "NoirProvingSchemeOptions",
+                    "description": "The supported Noir proving schemes.",
+                    "enum": [
+                        "barretenberg"
+                    ],
+                    "type": "string"
+                },
+                "NoirSindriManifest": {
+                    "title": "Sindri Manifest for Noir Circuits",
+                    "description": "Sindri Manifest for Noir circuits.",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "title": "Circuit Name",
+                            "description": "The circuit name used to uniquely identify the circuit within your organization. Similar to a GitHub project name or a Docker image name.",
+                            "pattern": "^[-a-zA-Z0-9_]+$",
+                            "error_messages": {
+                                "regex": "`name` must be a valid slug."
+                            },
+                            "type": "string"
+                        },
+                        "circuitType": {
+                            "title": "Circuit Type",
+                            "description": "The (frontend) development framework that your circuit is written with.",
+                            "enum": [
+                                "noir"
+                            ],
+                            "type": "string"
+                        },
+                        "provingScheme": {
+                            "description": "The backend proving scheme.",
+                            "default": "barretenberg",
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/NoirProvingSchemeOptions"
+                                }
+                            ]
+                        },
+                        "$schema": {
+                            "type": "string",
+                            "title": "Sindri Manifest JSON Schema URL",
+                            "description": "The URL pointing to a Sindri JSON Manifest schema definition.",
+                            "examples": [
+                                "https://sindri.app/api/v1/sindri-manifest-schema.json"
+                            ]
+                        }
+                    },
+                    "required": [
+                        "name",
+                        "circuitType"
+                    ],
+                    "additionalProperties": false
+                }
+            }
+        },
+        "rawHeaders": [
+            "Content-Length",
+            "14963",
+            "Content-Type",
+            "application/schema+json",
+            "Date",
+            "Sat, 06 Jan 2024 20:38:40 GMT",
+            "Referrer-Policy",
+            "same-origin",
+            "Server",
+            "gunicorn",
+            "Vary",
+            "Cookie, origin",
+            "X-Content-Type-Options",
+            "nosniff",
+            "X-Frame-Options",
+            "SAMEORIGIN",
+            "Connection",
+            "close"
+        ],
+        "responseIsBinary": false
+    }
+]

--- a/test/lib/testConfiguration.test.ts
+++ b/test/lib/testConfiguration.test.ts
@@ -1,8 +1,15 @@
-import test from "ava";
-
 import lib from "lib";
 
+import { test, useNock } from "./useNock";
+
+useNock();
+
 test("should get Sindri manifest schema JSON", async (t) => {
+  const schema = await lib.getSindriManifestSchema();
+  t.true(schema?.title?.includes("Sindri"));
+});
+
+test("should get Sindri manifest schema JSON duplicate", async (t) => {
   const schema = await lib.getSindriManifestSchema();
   t.true(schema?.title?.includes("Sindri"));
 });

--- a/test/lib/useNock.ts
+++ b/test/lib/useNock.ts
@@ -1,0 +1,38 @@
+import path from "path";
+import process from "process";
+
+import testWithoutContext, { type ExecutionContext, type TestFn } from "ava";
+import nock, { back as nockBack, type BackMode } from "nock";
+
+// Add the context to the test function type.
+type Context = {
+  nockDone: () => void;
+};
+export const test = testWithoutContext as TestFn<Context>;
+
+export const useNock = async () => {
+  // Prepare the nock fixture paths.
+  const testPath = test.meta.file.replace(/^file:/, "");
+  nockBack.fixtures = path.join(path.dirname(testPath), "fixtures");
+  const testFilenamePrefix = path.basename(testPath);
+  const fixtureFilename = `${testFilenamePrefix}.json`;
+  console.log("fixtures:", nockBack.fixtures, fixtureFilename);
+
+  test.before(async (t: ExecutionContext<Context>) => {
+    // Start recording, and only allow connections to `sindri.app`.
+    nock.disableNetConnect();
+    nock.enableNetConnect("sindri.app");
+    nockBack.setMode((process.env.NOCK_BACK_MODE ?? "lockdown") as BackMode);
+    const { nockDone } = await nockBack(fixtureFilename);
+    t.context.nockDone = nockDone;
+  });
+
+  test.after.always((t: ExecutionContext<Context>) => {
+    // Stop recording and re-enable all network connections.
+    if (t.context.nockDone) {
+      t.context.nockDone();
+    }
+    nock.enableNetConnect();
+    nockBack.setMode("wild");
+  });
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1430,7 +1430,7 @@ dateformat@^4.6.3:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-4.6.3.tgz#556fa6497e5217fedb78821424f8a1c22fa3f4b5"
   integrity sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==
 
-debug@4, debug@4.3.4, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
+debug@4, debug@4.3.4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -2491,6 +2491,11 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
+json-stringify-safe@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
+  integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
+
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
@@ -2763,6 +2768,20 @@ netmask@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/netmask/-/netmask-2.0.2.tgz#8b01a07644065d536383835823bc52004ebac5e7"
   integrity sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==
+
+nock-puppeteer@^14.4.1:
+  version "14.4.1"
+  resolved "https://registry.yarnpkg.com/nock-puppeteer/-/nock-puppeteer-14.4.1.tgz#e40eeb40c2784770d5be323dad2668867ec6278f"
+  integrity sha512-N4yeuljRPWN+TnKS5Wsb4LfyXmzNld7MBCPAdaRI+DWOighy/RywGuFSw7QlxhxyyeIajXuVh0M7vcgrnxdbQQ==
+
+nock@^13.4.0:
+  version "13.4.0"
+  resolved "https://registry.yarnpkg.com/nock/-/nock-13.4.0.tgz#60aa3f7a4afa9c12052e74d8fb7550f682ef0115"
+  integrity sha512-W8NVHjO/LCTNA64yxAPHV/K47LpGYcVzgKd3Q0n6owhwvD0Dgoterc25R4rnZbckJEb6Loxz1f5QMuJpJnbSyQ==
+  dependencies:
+    debug "^4.1.0"
+    json-stringify-safe "^5.0.1"
+    propagate "^2.0.0"
 
 node-fetch@^2.6.12, node-fetch@^2.6.7:
   version "2.7.0"
@@ -3137,6 +3156,11 @@ progress@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
+propagate@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
+  integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
 proxy-agent@6.3.1:
   version "6.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1391,13 +1391,6 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-cssstyle@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-3.0.0.tgz#17ca9c87d26eac764bb8cfd00583cff21ce0277a"
-  integrity sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==
-  dependencies:
-    rrweb-cssom "^0.6.0"
-
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -1409,14 +1402,6 @@ data-uri-to-buffer@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-6.0.1.tgz#540bd4c8753a25ee129035aebdedf63b078703c7"
   integrity sha512-MZd3VlchQkp8rdend6vrx7MmVDJzSNTBvghvKjirLkD+WTChA3KUf0jkE68Q4UyctNqI11zZO9/x2Yx+ub5Cvg==
-
-data-urls@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-5.0.0.tgz#2f76906bce1824429ffecb6920f45a0b30f00dde"
-  integrity sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==
-  dependencies:
-    whatwg-mimetype "^4.0.0"
-    whatwg-url "^14.0.0"
 
 date-time@^3.1.0:
   version "3.1.0"
@@ -1436,11 +1421,6 @@ debug@4, debug@4.3.4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, de
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
-
-decimal.js@^10.4.3:
-  version "10.4.3"
-  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.3.tgz#1044092884d245d1b7f65725fa4ad4c6f781cc23"
-  integrity sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==
 
 deep-extend@^0.6.0:
   version "0.6.0"
@@ -1539,11 +1519,6 @@ end-of-stream@^1.1.0:
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
-
-entities@^4.4.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
-  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
 env-paths@^2.2.1:
   version "2.2.1"
@@ -2176,13 +2151,6 @@ help-me@^4.0.1:
     glob "^8.0.0"
     readable-stream "^3.6.0"
 
-html-encoding-sniffer@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz#696df529a7cfd82446369dc5193e590a3735b448"
-  integrity sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==
-  dependencies:
-    whatwg-encoding "^3.1.1"
-
 http-proxy-agent@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-7.0.0.tgz#e9096c5afd071a3fce56e6252bb321583c124673"
@@ -2216,13 +2184,6 @@ human-signals@^4.3.0:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-4.3.1.tgz#ab7f811e851fca97ffbd2c1fe9a958964de321b2"
   integrity sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==
-
-iconv-lite@0.6.3:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
-  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
-  dependencies:
-    safer-buffer ">= 2.1.2 < 3.0.0"
 
 iconv-lite@^0.4.24:
   version "0.4.24"
@@ -2370,11 +2331,6 @@ is-plain-object@^5.0.0:
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
   integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
 
-is-potential-custom-element-name@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
-  integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
-
 is-promise@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-4.0.0.tgz#42ff9f84206c1991d26debf520dd5c01042dd2f3"
@@ -2436,33 +2392,6 @@ js-yaml@^4.1.0:
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
   dependencies:
     argparse "^2.0.1"
-
-jsdom@^23.0.1:
-  version "23.0.1"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-23.0.1.tgz#ede7ff76e89ca035b11178d200710d8982ebfee0"
-  integrity sha512-2i27vgvlUsGEBO9+/kJQRbtqtm+191b5zAZrU/UezVmnC2dlDAFLgDYJvAEi94T4kjsRKkezEtLQTgsNEsW2lQ==
-  dependencies:
-    cssstyle "^3.0.0"
-    data-urls "^5.0.0"
-    decimal.js "^10.4.3"
-    form-data "^4.0.0"
-    html-encoding-sniffer "^4.0.0"
-    http-proxy-agent "^7.0.0"
-    https-proxy-agent "^7.0.2"
-    is-potential-custom-element-name "^1.0.1"
-    nwsapi "^2.2.7"
-    parse5 "^7.1.2"
-    rrweb-cssom "^0.6.0"
-    saxes "^6.0.0"
-    symbol-tree "^3.2.4"
-    tough-cookie "^4.1.3"
-    w3c-xmlserializer "^5.0.0"
-    webidl-conversions "^7.0.0"
-    whatwg-encoding "^3.1.1"
-    whatwg-mimetype "^4.0.0"
-    whatwg-url "^14.0.0"
-    ws "^8.14.2"
-    xml-name-validator "^5.0.0"
 
 json-buffer@3.0.1:
   version "3.0.1"
@@ -2845,11 +2774,6 @@ nunjucks@^3.2.4:
     asap "^2.0.3"
     commander "^5.1.0"
 
-nwsapi@^2.2.7:
-  version "2.2.7"
-  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.7.tgz#738e0707d3128cb750dddcfe90e4610482df0f30"
-  integrity sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==
-
 object-assign@^4.0.1, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
@@ -2990,13 +2914,6 @@ parse-ms@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-3.0.0.tgz#3ea24a934913345fcc3656deda72df921da3a70e"
   integrity sha512-Tpb8Z7r7XbbtBTrM9UhpkzzaMrqA2VXMT3YChzYltwV3P3pM6t8wl7TvpMnSTosz1aQAdVib7kdoys7vYOPerw==
-
-parse5@^7.1.2:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.1.2.tgz#0736bebbfd77793823240a23b7fc5e010b7f8e32"
-  integrity sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==
-  dependencies:
-    entities "^4.4.0"
 
 path-exists@^4.0.0:
   version "4.0.0"
@@ -3181,11 +3098,6 @@ proxy-from-env@^1.1.0:
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
-psl@^1.1.33:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
-  integrity sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==
-
 pump@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
@@ -3194,7 +3106,7 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
-punycode@^2.1.0, punycode@^2.1.1, punycode@^2.3.1:
+punycode@^2.1.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
@@ -3219,11 +3131,6 @@ puppeteer@^21.7.0:
     "@puppeteer/browsers" "1.9.1"
     cosmiconfig "8.3.6"
     puppeteer-core "21.7.0"
-
-querystringify@^2.1.1:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
-  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -3287,11 +3194,6 @@ require-directory@^2.1.1:
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
 
-requires-port@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
-  integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
-
 resolve-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
@@ -3345,11 +3247,6 @@ rollup@^4.0.2:
     "@rollup/rollup-win32-x64-msvc" "4.4.1"
     fsevents "~2.3.2"
 
-rrweb-cssom@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz#ed298055b97cbddcdeb278f904857629dec5e0e1"
-  integrity sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==
-
 run-applescript@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/run-applescript/-/run-applescript-5.0.0.tgz#e11e1c932e055d5c6b40d98374e0268d9b11899c"
@@ -3379,17 +3276,10 @@ safe-stable-stringify@^2.3.1:
   resolved "https://registry.yarnpkg.com/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz#138c84b6f6edb3db5f8ef3ef7115b8f55ccbf886"
   integrity sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==
 
-"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0":
+"safer-buffer@>= 2.1.2 < 3":
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
-
-saxes@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/saxes/-/saxes-6.0.0.tgz#fe5b4a4768df4f14a201b1ba6a65c1f3d9988cc5"
-  integrity sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==
-  dependencies:
-    xmlchars "^2.2.0"
 
 secure-json-parse@^2.4.0:
   version "2.7.0"
@@ -3622,11 +3512,6 @@ supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-symbol-tree@^3.2.4:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
-  integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
-
 synckit@^0.8.5:
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/synckit/-/synckit-0.8.5.tgz#b7f4358f9bb559437f9f167eb6bc46b3c9818fa3"
@@ -3725,29 +3610,12 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-tough-cookie@^4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.3.tgz#97b9adb0728b42280aa3d814b6b999b2ff0318bf"
-  integrity sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==
-  dependencies:
-    psl "^1.1.33"
-    punycode "^2.1.1"
-    universalify "^0.2.0"
-    url-parse "^1.5.3"
-
 tr46@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
   integrity sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==
   dependencies:
     punycode "^2.1.0"
-
-tr46@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-5.0.0.tgz#3b46d583613ec7283020d79019f1335723801cec"
-  integrity sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==
-  dependencies:
-    punycode "^2.3.1"
 
 tr46@~0.0.3:
   version "0.0.3"
@@ -3869,11 +3737,6 @@ universalify@^0.1.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
-universalify@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
-  integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
-
 universalify@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
@@ -3891,14 +3754,6 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-url-parse@^1.5.3:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
-  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
-  dependencies:
-    querystringify "^2.1.1"
-    requires-port "^1.0.0"
-
 urlpattern-polyfill@9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/urlpattern-polyfill/-/urlpattern-polyfill-9.0.0.tgz#bc7e386bb12fd7898b58d1509df21d3c29ab3460"
@@ -3909,13 +3764,6 @@ util-deprecate@^1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
-w3c-xmlserializer@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz#f925ba26855158594d907313cedd1476c5967f6c"
-  integrity sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==
-  dependencies:
-    xml-name-validator "^5.0.0"
-
 webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
@@ -3925,11 +3773,6 @@ webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
-
-webidl-conversions@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
-  integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
 
 well-known-symbols@^2.0.0:
   version "2.0.0"
@@ -3943,26 +3786,6 @@ wget-improved@^3.4.0:
   dependencies:
     minimist "1.2.6"
     tunnel "0.0.6"
-
-whatwg-encoding@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz#d0f4ef769905d426e1688f3e34381a99b60b76e5"
-  integrity sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==
-  dependencies:
-    iconv-lite "0.6.3"
-
-whatwg-mimetype@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz#bc1bf94a985dc50388d54a9258ac405c3ca2fc0a"
-  integrity sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==
-
-whatwg-url@^14.0.0:
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-14.0.0.tgz#00baaa7fd198744910c4b1ef68378f2200e4ceb6"
-  integrity sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==
-  dependencies:
-    tr46 "^5.0.0"
-    webidl-conversions "^7.0.0"
 
 whatwg-url@^5.0.0:
   version "5.0.0"
@@ -4031,20 +3854,10 @@ write-file-atomic@^5.0.1:
     imurmurhash "^0.1.4"
     signal-exit "^4.0.1"
 
-ws@8.16.0, ws@^8.14.2:
+ws@8.16.0:
   version "8.16.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.16.0.tgz#d1cd774f36fbc07165066a60e40323eab6446fd4"
   integrity sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==
-
-xml-name-validator@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-5.0.0.tgz#82be9b957f7afdacf961e5980f1bf227c0bf7673"
-  integrity sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==
-
-xmlchars@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
-  integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
 y18n@^5.0.5:
   version "5.0.8"


### PR DESCRIPTION
This integrates nock and nock-puppeteer with the project so that we can record fixtures of requests in the tests. This works with both the node and browser tests.
