### PR TITLE
Fix API-key/team association

### DIFF
--- a/src/cli/login.ts
+++ b/src/cli/login.ts
@@ -101,6 +101,7 @@ export const loginCommand = new Command()
       }
 
       // Generate an API key.
+      OpenAPI.HEADERS = { "Sindri-Team-Id": `${teamId}` };
       const apiKeyResult = await AuthorizationService.apikeyGenerate({
         username,
         password,


### PR DESCRIPTION
The selected team ID was not being associated with the newly created API key in `sindri login`. This adds the necessary header to properly associate it.
