### PR TITLE
Include @types/ packages as production dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,11 +89,6 @@
     "rc": "^1.2.8",
     "tar": "^6.2.0",
     "tar-js": "^0.3.0",
-    "zod": "^3.22.4"
-  },
-  "devDependencies": {
-    "@ava/typescript": "^4.1.0",
-    "@commander-js/extra-typings": "^11.1.0",
     "@tsconfig/node18": "^18.2.2",
     "@types/get-port": "^4.2.0",
     "@types/gzip-js": "^0.3.5",
@@ -104,6 +99,11 @@
     "@types/proxy": "^1.0.4",
     "@types/tar": "^6.1.10",
     "@types/tar-js": "^0.3.5",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@ava/typescript": "^4.1.0",
+    "@commander-js/extra-typings": "^11.1.0",
     "@typescript-eslint/eslint-plugin": "^6.11.0",
     "@typescript-eslint/parser": "^6.11.0",
     "ava": "^6.0.1",


### PR DESCRIPTION
These are necessary for building the docs and are also helpful to have around for anybody developing with the SDK.
