### PR TITLE
Pull API key from `Client` instance in CLI commands

### DIFF
--- a/src/cli/deploy.ts
+++ b/src/cli/deploy.ts
@@ -9,8 +9,7 @@ import walk from "ignore-walk";
 import tar from "tar";
 
 import { findFileUpwards } from "cli/utils";
-import { ApiError, CircuitsService, CircuitStatus } from "lib/api";
-import { Config } from "lib/config";
+import { ApiError, CircuitsService, CircuitStatus, OpenAPI } from "lib/api";
 import { logger } from "lib/logging";
 
 export const deployCommand = new Command()
@@ -84,10 +83,8 @@ export const deployCommand = new Command()
     }
     const circuitName = sindriJson.name;
 
-    // Authorize the API client.
-    const config = new Config();
-    const auth = config.auth;
-    if (!auth) {
+    // Check that the API client is authorized.
+    if (!OpenAPI.TOKEN || !OpenAPI.BASE) {
       logger.warn("You must login first with `sindri login`.");
       return process.exit(1);
     }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,4 +1,5 @@
 #! /usr/bin/env node
+import assert from "assert";
 import { argv, exit } from "process";
 
 import { Command } from "@commander-js/extra-typings";
@@ -11,7 +12,7 @@ import { loginCommand } from "cli/login";
 import { logoutCommand } from "cli/logout";
 import { whoamiCommand } from "cli/whoami";
 import { loadPackageJson } from "cli/utils";
-import { Config } from "lib/config";
+import sindri from "lib";
 import { logger } from "lib/logging";
 
 export const program = new Command()
@@ -50,8 +51,9 @@ export const program = new Command()
     }
     logger.debug(`Set log level to "${logger.level}".`);
 
-    // Force the loading of the config before subcommands.
-    new Config();
+    // Make sure the client is loaded and initialized before any subcommands run.
+    // Note that this also initializes the config.
+    assert(sindri);
   });
 
 if (require.main === module) {

--- a/src/cli/whoami.ts
+++ b/src/cli/whoami.ts
@@ -2,18 +2,15 @@ import process from "process";
 
 import { Command } from "@commander-js/extra-typings";
 
-import { ApiError, InternalService } from "lib/api";
-import { Config } from "lib/config";
+import { ApiError, InternalService, OpenAPI } from "lib/api";
 import { logger, print } from "lib/logging";
 
 export const whoamiCommand = new Command()
   .name("whoami")
   .description("Display the currently authorized organization name.")
   .action(async () => {
-    // Authorize the API client.
-    const config = new Config();
-    const auth = config.auth;
-    if (!auth) {
+    // Check that the API client is authorized.
+    if (!OpenAPI.TOKEN || !OpenAPI.BASE) {
       logger.warn("You must login first with `sindri login`.");
       return process.exit(1);
     }


### PR DESCRIPTION
This updates the CLI commands to use the `Client` credentials instead of the `Config` ones because these can be overridden by the `SINDRI_API_KEY` and `SINDRI_BASE_URL`. Some of the commands, like `logout` seemed like they made more sense to still use the `Config` ones because they're specifically tied to updating the config file.
