### PR TITLE
Fix ESM imports

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import path from "path";
 
 import envPaths from "env-paths";
-import { cloneDeep, merge } from "lodash";
+import _ from "lodash";
 import { z } from "zod";
 
 import { OpenAPI } from "lib/api";
@@ -56,7 +56,7 @@ export const loadConfig = (): ConfigSchema => {
   logger.debug(
     `Config file "${configPath}" does not exist, initializing default config.`,
   );
-  return cloneDeep(defaultConfig);
+  return _.cloneDeep(defaultConfig);
 };
 
 export class Config {
@@ -77,19 +77,19 @@ export class Config {
   }
 
   get auth(): ConfigSchema["auth"] {
-    return cloneDeep(this._config.auth);
+    return _.cloneDeep(this._config.auth);
   }
 
   get config(): ConfigSchema {
-    return cloneDeep(this._config);
+    return _.cloneDeep(this._config);
   }
 
   update(configData: Partial<ConfigSchema>) {
     // Merge and validate the configs.
     logger.debug("Merging in config update:");
     logger.debug(configData);
-    const newConfig: ConfigSchema = cloneDeep(this._config);
-    merge(newConfig, configData);
+    const newConfig: ConfigSchema = _.cloneDeep(this._config);
+    _.merge(newConfig, configData);
     this._config = ConfigSchema.parse(newConfig);
 
     // Create the directory if it doesn't exist.

--- a/test/utils/matchFormPayloads.ts
+++ b/test/utils/matchFormPayloads.ts
@@ -1,4 +1,4 @@
-import { isEqual } from "lodash";
+import _ from "lodash";
 import makeSynchronous from "make-synchronous";
 import { type Definition as NockDefinition } from "nock";
 import * as multipart from "parse-multipart-data";
@@ -114,7 +114,7 @@ export function matchFormPayloads(scope: NockDefinition) {
       ) {
         const tarball = parseTarball(part.data);
         const recordedTarball = parseTarball(part.data);
-        if (!isEqual(tarball, recordedTarball)) {
+        if (!_.isEqual(tarball, recordedTarball)) {
           return body;
         }
       } else {


### PR DESCRIPTION
The ESM builds were broken because lodash is a CJS-only package. This imports the entire library as `_` for now to resolve this. We should add a test that the imports work in the future.
