### PR TITLE
Bump the setup-node action version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Setup Node.js
         id: setup-node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.version }}
           cache: yarn


### PR DESCRIPTION
The v3 version based on node v16 is deprecated, v4 uses node v20.
