### PR TITLE
Remove `@types/get-port` stub dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "@commander-js/extra-typings": "^11.1.0",
     "@inquirer/prompts": "^3.3.0",
     "@tsconfig/node18": "^18.2.2",
-    "@types/get-port": "^4.2.0",
     "@types/gzip-js": "^0.3.5",
     "@types/ignore-walk": "^4.0.3",
     "@types/lodash": "^4.14.202",

--- a/yarn.lock
+++ b/yarn.lock
@@ -813,13 +813,6 @@
   resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz"
   integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
 
-"@types/get-port@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.npmjs.org/@types/get-port/-/get-port-4.2.0.tgz"
-  integrity sha512-Iv2FAb5RnIk/eFO2CTu8k+0VMmIR15pKbcqRWi+s3ydW+aKXlN2yemP92SrO++ERyJx+p6Ie1ggbLBMbU1SjiQ==
-  dependencies:
-    get-port "*"
-
 "@types/gzip-js@^0.3.5":
   version "0.3.5"
   resolved "https://registry.npmjs.org/@types/gzip-js/-/gzip-js-0.3.5.tgz"
@@ -2329,7 +2322,7 @@ get-intrinsic@^1.1.3, get-intrinsic@^1.2.1, get-intrinsic@^1.2.2:
     has-symbols "^1.0.3"
     hasown "^2.0.0"
 
-get-port@*, get-port@^7.0.0:
+get-port@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/get-port/-/get-port-7.0.0.tgz"
   integrity sha512-mDHFgApoQd+azgMdwylJrv2DX47ywGq1i5VFJE7fZ0dttNq3iQMfsU4IvEgBHojA3KqEudyu7Vq+oN8kNaNkWw==


### PR DESCRIPTION
The types are already provided by `get-port`, this was a stub that logs a warning upon installation.
