### PR TITLE
Update noir scaffold version field

### DIFF
--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -236,6 +236,18 @@ export const initCommand = new Command()
           return true;
         },
       });
+      const noirVersion: "0.17.0" | "0.18.0" | "0.19.4" | "0.22.0" | "0.23.0" =
+        await select({
+          message: "Noir Version:",
+          default: "0.23.0",
+          choices: [
+            { name: "0.17.0", value: "0.17.0" },
+            { name: "0.18.0", value: "0.18.0" },
+            { name: "0.19.4", value: "0.19.4" },
+            { name: "0.22.0", value: "0.22.0" },
+            { name: "0.23.0", value: "0.23.0" },
+          ],
+        });
       const provingScheme: "barretenberg" = await select({
         message: "Proving Scheme:",
         default: "barretenberg",
@@ -243,6 +255,7 @@ export const initCommand = new Command()
       });
       Object.assign(context, {
         packageName,
+        noirVersion,
         provingScheme,
       });
     } else {

--- a/templates/noir/Nargo.toml
+++ b/templates/noir/Nargo.toml
@@ -2,6 +2,6 @@
 name = "{{ packageName }}"
 type = "bin"
 authors = [""]
-compiler_version = "0.19.3"
+compiler_version = "{{ noirVersion }}"
 
 [dependencies]

--- a/templates/noir/sindri.json
+++ b/templates/noir/sindri.json
@@ -2,5 +2,6 @@
   "$schema": "https://sindri.app/api/v1/sindri-manifest-schema.json",
   "name": "{{ circuitName }}",
   "circuitType": "noir",
-  "provingScheme": "{{ provingScheme }}"
+  "provingScheme": "{{ provingScheme }}",
+  "noirVersion": "{{ noirVersion }}"
 }


### PR DESCRIPTION
Previously our `sindri init` scaffold built a noir circuit with Nargo.toml specifying the compiler version as `0.19.3`.  Since the `sindri.json` does not contain a `noirVersion` field, the most recent API release will assume you intend to use 0.23.0.  This will cause a Nargo compilation error.

This PR introduces a `noirVersion` field supplied by the user to pass into the `Nargo.toml` and `sindri.json`.  The options for this field match our current support.