### PR TITLE
Fix `/tmp/` dir mounting on macos in docker

### DIFF
--- a/src/cli/lint.ts
+++ b/src/cli/lint.ts
@@ -1,7 +1,6 @@
 import assert from "assert";
 import { randomUUID } from "crypto";
 import { existsSync, readFileSync, unlinkSync } from "fs";
-import os from "os";
 import path from "path";
 import process from "process";
 
@@ -195,7 +194,8 @@ export const lintCommand = new Command()
           "Running static analysis with Circomspect by Trail of Bits...",
         );
         const sarifFile = path.join(
-          os.tmpdir(),
+          "/",
+          "/tmp/",
           "sindri",
           `circomspect-${randomUUID()}.sarif`,
         );

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -299,7 +299,7 @@ export async function execDockerCommand(
               // Circuit project root.
               `${mountDirectory}:/sindri`,
               // Shared temporary directory.
-              `${os.tmpdir()}/sindri/:/tmp/sindri/`,
+              `/tmp/sindri/:/tmp/sindri/`,
             ],
           },
           OpenStdin: tty,


### PR DESCRIPTION
The `os.tmpdir()` call was returning a path under `/var/folders/` on macs, so the Circomspect output was ending up in a different location than the CLI was expecting it. This hardcodes the path to `/tmp/` which is effectively all we support at the moment. Windows support outside of WSL will be more complicated because it will require further path rewriting.
