### PR TITLE
Integrate nargo with `sindri x nargo`

### DIFF
--- a/src/cli/exec.ts
+++ b/src/cli/exec.ts
@@ -46,6 +46,32 @@ const circomspectCommand = new Command()
     }
   });
 
+const nargoCommand = new Command()
+  .name("nargo")
+  .description("Aztec Lab's Noir compiler and package manager.")
+  .helpOption(false)
+  .addHelpCommand(false)
+  .allowUnknownOption()
+  .passThroughOptions()
+  .argument("[args...]", "Arguments to pass to the tool.")
+  .action(async (args) => {
+    if (listTags) return; // Don't run the command if we're just listing tags.
+
+    try {
+      const code = await execDockerCommand("nargo", args, {
+        logger: sindri.logger,
+        rootDirectory,
+        tag,
+        tty: true,
+      });
+      process.exit(code);
+    } catch (error) {
+      sindri.logger.error("Failed to run the nargo command.");
+      sindri.logger.debug(error);
+      return process.exit(1);
+    }
+  });
+
 export const execCommand = new Command()
   .name("exec")
   .alias("x")
@@ -63,6 +89,7 @@ export const execCommand = new Command()
     "auto",
   )
   .addCommand(circomspectCommand)
+  .addCommand(nargoCommand)
   .hook("preAction", async (command) => {
     // Store the options in globals for subcommands to access them.
     const opts = command.opts();

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -228,9 +228,11 @@ export async function execDockerCommand(
           encoding: "utf-8",
         });
         const sindriJson = JSON.parse(sindriJsonContent);
-        tag = sindriJson.noirVersion;
-        if (tag && !tag.startsWith("v")) {
-          tag = `v${tag}`;
+        if (sindriJson.noirVersion) {
+          tag = sindriJson.noirVersion;
+          if (tag && !tag.startsWith("v")) {
+            tag = `v${tag}`;
+          }
         }
       } catch (error) {
         logger?.error(


### PR DESCRIPTION
This integrates nargo as a `sindri x` command. The nargo version is automatically pulled from `sindri.json` by default, otherwise it uses the `latest` tag.
