### PR TITLE
Fix axiom-v0.3.0 manifest linting bug

### DIFF
--- a/src/cli/lint.ts
+++ b/src/cli/lint.ts
@@ -110,7 +110,7 @@ export const lintCommand = new Command()
         sindriJson.halo2Version === "axiom-v0.3.0"
       ) {
         subSchema = sindriManifestJsonSchema.anyOf.find((option: Schema) =>
-          /halo2axiomv022/i.test(option["$ref"] ?? ""),
+          /halo2axiomv030/i.test(option["$ref"] ?? ""),
         );
       } else {
         // We can't discriminate the different halo2 manifests if there's not a valid `halo2Version`


### PR DESCRIPTION
This was a typo bug which was incorrectly narrowing the axiom-v0.3.0 schema type to axiom-v0.2.2.
