### PR TITLE
Allow periods in circuit tag names

### DIFF
--- a/src/cli/deploy.ts
+++ b/src/cli/deploy.ts
@@ -29,10 +29,10 @@ export const deployCommand = new Command()
       }
     } else {
       for (const tag of tags) {
-        if (!/^[-a-zA-Z0-9_]+$/.test(tag)) {
+        if (!/^[-a-zA-Z0-9_.]+$/.test(tag)) {
           sindri.logger.error(
             `"${tag}" is not a valid tag. Tags may only contain alphanumeric characters, ` +
-              "underscores, and hyphens.",
+              "underscores, hyphens, and periods.",
           );
           return process.exit(1);
         }

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -330,10 +330,10 @@ export class SindriClient {
     // First, validate the tags and them to the form data.
     tags = typeof tags === "string" ? [tags] : tags ?? [];
     for (const tag of tags) {
-      if (!/^[-a-zA-Z0-9_]+$/.test(tag)) {
+      if (!/^[-a-zA-Z0-9_.]+$/.test(tag)) {
         throw new Error(
           `"${tag}" is not a valid tag. Tags may only contain alphanumeric characters, ` +
-            "underscores, and hyphens.",
+            "underscores, hyphens, and periods.",
         );
       }
       formData.append("tags", tag);


### PR DESCRIPTION
We previously only allowed alphanumeric characters, hyphens, and underscores. This adds periods so that you can use version tags like `v1.0.0` or `v0.0.0-alpha.30`.
