### PR TITLE
Add a `sindri clone` CLI command

### DIFF
--- a/src/cli/clone.ts
+++ b/src/cli/clone.ts
@@ -1,0 +1,104 @@
+import assert from "assert";
+import fs from "fs";
+import path from "path";
+import process from "process";
+
+import { Command } from "@commander-js/extra-typings";
+import tar from "tar";
+
+import sindri from "lib";
+import { ApiError } from "lib/api";
+
+export const cloneCommand = new Command()
+  .name("clone")
+  .description("Clone a circuit into a local directory.")
+  .argument("<circuit>", "The circuit to clone.")
+  .argument("[directory]", "The directory to clone the circuit into.")
+  .action(async (circuit, directory) => {
+    // Validate the circuit identifier.
+    const circuitIdentifierRegex =
+      /^(?:([-a-zA-Z0-9_]+)\/)?([-a-zA-Z0-9_]+)(?::([-a-zA-Z0-9_.]+))?$/;
+    const match = circuitIdentifierRegex.exec(circuit);
+    if (!match) {
+      sindri.logger.error(`"${circuit}" is not a valid circuit identifier.`);
+      return process.exit(1);
+    }
+    assert(match[2], "The circuit name must be provided.");
+    const circuitName: string = match[2];
+    const outputDirectory: string = path.resolve(directory ?? circuitName);
+
+    // Check that the output directory does not exist.
+    if (fs.existsSync(outputDirectory)) {
+      sindri.logger.error(
+        `The directory "${outputDirectory}" already exists. Aborting.`,
+      );
+      return process.exit(1);
+    }
+
+    // Check that the API client is authorized.
+    if (!sindri.apiKey || !sindri.baseUrl) {
+      sindri.logger.warn("You must login first with `sindri login`.");
+      return process.exit(1);
+    }
+
+    // Request the circuit tarball from the server.
+    let responseStream: NodeJS.ReadableStream;
+    sindri.logger.info(
+      `Cloning the circuit "${circuit}" into "${outputDirectory}".`,
+    );
+    try {
+      responseStream = (await sindri._client.internal.circuitDownload(
+        circuit,
+      )) as unknown as NodeJS.ReadableStream;
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 401) {
+        sindri.logger.error(
+          "Your credentials are invalid. Please log in again with `sindri login`.",
+        );
+        return process.exit(1);
+      } else if (error instanceof ApiError && error.status === 404) {
+        sindri.logger.error(
+          `The circuit "${circuit}" does not exist or you lack permission to access it.`,
+        );
+        return process.exit(1);
+      } else {
+        sindri.logger.fatal("An unknown error occurred.");
+        sindri.logger.error(error);
+        return process.exit(1);
+      }
+    }
+
+    // Make the output directory.
+    try {
+      fs.mkdirSync(outputDirectory, { recursive: true });
+    } catch (error) {
+      sindri.logger.fatal(
+        `Failed to create the directory "${outputDirectory}". Aborting.`,
+      );
+      sindri.logger.error(error);
+      return process.exit(1);
+    }
+
+    // Extract the tarball into the output directory.
+    await new Promise((resolve, reject) => {
+      responseStream.on("end", resolve);
+      responseStream.on("error", reject);
+      responseStream.pipe(
+        tar.x({
+          cwd: outputDirectory,
+          noChmod: true,
+          noMtime: true,
+          onwarn: (code: string, message: string) => {
+            sindri.logger.warn(
+              `While extracting tarball: ${code} - ${message}`,
+            );
+          },
+          preserveOwner: false,
+          // @ts-expect-error - `preservePaths` is missing from the library's type definitions.
+          preservePaths: false,
+          strip: 1,
+        }),
+      );
+    });
+    sindri.logger.info("Circuit cloned successfully.");
+  });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -3,6 +3,7 @@ import { argv, exit } from "process";
 
 import { Command } from "@commander-js/extra-typings";
 
+import { cloneCommand } from "cli/clone";
 import { configCommand } from "cli/config";
 import { execCommand } from "cli/exec";
 import { initCommand } from "cli/init";
@@ -29,6 +30,7 @@ export const program = new Command()
     "Disable all logging aside from direct command outputs for programmatic consumption.",
     false,
   )
+  .addCommand(cloneCommand)
   .addCommand(configCommand)
   .addCommand(execCommand)
   .addCommand(initCommand)

--- a/src/lib/api/core/ApiRequestOptions.ts
+++ b/src/lib/api/core/ApiRequestOptions.ts
@@ -21,4 +21,6 @@ export type ApiRequestOptions = {
   readonly mediaType?: string;
   readonly responseHeader?: string;
   readonly errors?: Record<number, string>;
+  readonly responseType?: // DO NOT REMOVE
+  "arraybuffer" | "blob" | "document" | "json" | "text" | "stream";
 };

--- a/src/lib/api/core/request.ts
+++ b/src/lib/api/core/request.ts
@@ -250,6 +250,7 @@ export const sendRequest = async <T>(
     method: options.method,
     withCredentials: config.WITH_CREDENTIALS,
     cancelToken: source.token,
+    responseType: options.responseType,
   };
 
   onCancel(() => source.cancel("The user aborted a request."));
@@ -397,6 +398,10 @@ export const request = <T>(
           config.logger?.debug(
             `${responseMessage} - ${result.body || "<empty-body>"}`,
           );
+        } else if (options.responseType === "stream") {
+          config.logger?.debug(`${responseMessage} - <streaming-response>`);
+        } else if (options.responseType === "blob") {
+          config.logger?.debug(`${responseMessage} - <blob-response>`);
         } else {
           config.logger?.debug(result.body, responseMessage);
         }

--- a/src/lib/api/models/CircomCircuitInfoResponse.ts
+++ b/src/lib/api/models/CircomCircuitInfoResponse.ts
@@ -42,11 +42,11 @@ export type CircomCircuitInfoResponse = {
    */
   team: string;
   /**
-   * Total compute time in ISO8601 format. This does not include the Queued time.
+   * Total compute time in ISO8601 format.
    */
   compute_time?: number;
   /**
-   * Total compute time in seconds. This does not include the Queued time.
+   * Total compute time in seconds.
    */
   compute_time_sec?: number;
   /**
@@ -57,6 +57,14 @@ export type CircomCircuitInfoResponse = {
    * Total size of stored file(s) in bytes.
    */
   file_size?: number;
+  /**
+   * Queue time in ISO8601 format.
+   */
+  queue_time?: number;
+  /**
+   * Queue time in seconds.
+   */
+  queue_time_sec?: number;
   /**
    * The name of the uploaded circuit file. Note: the CLI and SDKs create a generic name when a directory is specified for upload.
    */

--- a/src/lib/api/models/GnarkCircuitInfoResponse.ts
+++ b/src/lib/api/models/GnarkCircuitInfoResponse.ts
@@ -42,11 +42,11 @@ export type GnarkCircuitInfoResponse = {
    */
   team: string;
   /**
-   * Total compute time in ISO8601 format. This does not include the Queued time.
+   * Total compute time in ISO8601 format.
    */
   compute_time?: number;
   /**
-   * Total compute time in seconds. This does not include the Queued time.
+   * Total compute time in seconds.
    */
   compute_time_sec?: number;
   /**
@@ -57,6 +57,14 @@ export type GnarkCircuitInfoResponse = {
    * Total size of stored file(s) in bytes.
    */
   file_size?: number;
+  /**
+   * Queue time in ISO8601 format.
+   */
+  queue_time?: number;
+  /**
+   * Queue time in seconds.
+   */
+  queue_time_sec?: number;
   /**
    * The name of the uploaded circuit file. Note: the CLI and SDKs create a generic name when a directory is specified for upload.
    */

--- a/src/lib/api/models/Halo2CircuitInfoResponse.ts
+++ b/src/lib/api/models/Halo2CircuitInfoResponse.ts
@@ -42,11 +42,11 @@ export type Halo2CircuitInfoResponse = {
    */
   team: string;
   /**
-   * Total compute time in ISO8601 format. This does not include the Queued time.
+   * Total compute time in ISO8601 format.
    */
   compute_time?: number;
   /**
-   * Total compute time in seconds. This does not include the Queued time.
+   * Total compute time in seconds.
    */
   compute_time_sec?: number;
   /**
@@ -57,6 +57,14 @@ export type Halo2CircuitInfoResponse = {
    * Total size of stored file(s) in bytes.
    */
   file_size?: number;
+  /**
+   * Queue time in ISO8601 format.
+   */
+  queue_time?: number;
+  /**
+   * Queue time in seconds.
+   */
+  queue_time_sec?: number;
   /**
    * The name of the uploaded circuit file. Note: the CLI and SDKs create a generic name when a directory is specified for upload.
    */

--- a/src/lib/api/models/NoirCircuitInfoResponse.ts
+++ b/src/lib/api/models/NoirCircuitInfoResponse.ts
@@ -42,11 +42,11 @@ export type NoirCircuitInfoResponse = {
    */
   team: string;
   /**
-   * Total compute time in ISO8601 format. This does not include the Queued time.
+   * Total compute time in ISO8601 format.
    */
   compute_time?: number;
   /**
-   * Total compute time in seconds. This does not include the Queued time.
+   * Total compute time in seconds.
    */
   compute_time_sec?: number;
   /**
@@ -57,6 +57,14 @@ export type NoirCircuitInfoResponse = {
    * Total size of stored file(s) in bytes.
    */
   file_size?: number;
+  /**
+   * Queue time in ISO8601 format.
+   */
+  queue_time?: number;
+  /**
+   * Queue time in seconds.
+   */
+  queue_time_sec?: number;
   /**
    * The name of the uploaded circuit file. Note: the CLI and SDKs create a generic name when a directory is specified for upload.
    */

--- a/src/lib/api/models/ProofInfoResponse.ts
+++ b/src/lib/api/models/ProofInfoResponse.ts
@@ -39,17 +39,20 @@ export type ProofInfoResponse = {
    */
   status: JobStatus;
   /**
-   * The user/team that owns this circuit for this proof.
+   * The user/team that owns this proof.
    */
   team: string;
   /**
-   * Total compute time in ISO8601 format. This does not include the Queued time.
+   * Total compute time in ISO8601 format.
    */
   compute_time?: number;
   /**
-   * Total compute time in seconds. This does not include the Queued time.
+   * Total compute time in seconds.
    */
   compute_time_sec?: number;
+  /**
+   * Detailed compute times for the proof generation.
+   */
   compute_times?: any;
   /**
    * Total size of stored file(s) in bytes.
@@ -63,6 +66,14 @@ export type ProofInfoResponse = {
    * The public outputs of the circuit.
    */
   public?: any;
+  /**
+   * Queue time in ISO8601 format.
+   */
+  queue_time?: number;
+  /**
+   * Queue time in seconds.
+   */
+  queue_time_sec?: number;
   /**
    * The proof and public formatted as calldata for the smart contract verifier.
    */

--- a/src/lib/api/services/CircuitsService.ts
+++ b/src/lib/api/services/CircuitsService.ts
@@ -45,6 +45,27 @@ export class CircuitsService {
   }
 
   /**
+   * Circuit Download
+   * Return the gzipped tarball for the specified circuit.
+   * @param circuitId
+   * @returns any OK
+   * @throws ApiError
+   */
+  public circuitDownload(circuitId: string): CancelablePromise<any> {
+    return this.httpRequest.request({
+      method: "GET",
+      url: "/api/v1/circuit/{circuit_id}/download",
+      path: {
+        circuit_id: circuitId,
+      },
+      errors: {
+        404: `Not Found`,
+        500: `Internal Server Error`,
+      },
+    });
+  }
+
+  /**
    * Circuit List
    * Return a list of CircuitInfoResponse for circuits related to user.
    * @param includeVerificationKey

--- a/src/lib/api/services/InternalService.ts
+++ b/src/lib/api/services/InternalService.ts
@@ -14,6 +14,27 @@ export class InternalService {
   constructor(public readonly httpRequest: BaseHttpRequest) {}
 
   /**
+   * Circuit Download
+   * Return the gzipped tarball for the specified circuit.
+   * @param circuitId
+   * @returns binary OK
+   * @throws ApiError
+   */
+  public circuitDownload(circuitId: string): CancelablePromise<Blob> {
+    return this.httpRequest.request({
+      method: "GET",
+      url: "/api/v1/circuit/{circuit_id}/download",
+      path: {
+        circuit_id: circuitId,
+      },
+      errors: {
+        404: `Not Found`,
+        500: `Internal Server Error`,
+      },
+    });
+  }
+
+  /**
    * Circuit Smart Contract Verifier
    * Get smart contract verifier for existing circuit
    * @param circuitId

--- a/src/lib/api/services/InternalService.ts
+++ b/src/lib/api/services/InternalService.ts
@@ -10,6 +10,11 @@ import type { UserMeResponse } from "../models/UserMeResponse";
 import type { CancelablePromise } from "../core/CancelablePromise";
 import type { BaseHttpRequest } from "../core/BaseHttpRequest";
 
+// DO NOT REMOVE
+type BinaryResponseType = typeof globalThis extends { ReadableStream: unknown }
+  ? Blob
+  : NodeJS.ReadableStream;
+
 export class InternalService {
   constructor(public readonly httpRequest: BaseHttpRequest) {}
 
@@ -20,7 +25,10 @@ export class InternalService {
    * @returns binary OK
    * @throws ApiError
    */
-  public circuitDownload(circuitId: string): CancelablePromise<Blob> {
+  public circuitDownload(
+    circuitId: string,
+    // DO NOT REMOVE
+  ): CancelablePromise<BinaryResponseType> {
     return this.httpRequest.request({
       method: "GET",
       url: "/api/v1/circuit/{circuit_id}/download",
@@ -31,6 +39,7 @@ export class InternalService {
         404: `Not Found`,
         500: `Internal Server Error`,
       },
+      responseType: process.env.BROWSER_BUILD ? "blob" : "stream", // DO NOT REMOVE
     });
   }
 

--- a/templates/noir/.sindriignore
+++ b/templates/noir/.sindriignore
@@ -1,3 +1,1 @@
 /targets/
-Prover.toml
-Verifier.toml


### PR DESCRIPTION
This adds a `sindri clone` command which can be used to download either your own circuit or somebody else's public circuit. You can either specify an exact circuit UUID or DockerHub inspired identifiers like `<circuit-name>`, `<circuit-name>:<tag>`, `<team>/<circuit-name>`, or `<team>/<circuit-name>:<tag>`.

```
Usage: sindri clone [options] <circuit> [directory]

Clone a circuit into a local directory.

Arguments:
circuit     The circuit to clone.
directory   The directory to clone the circuit into.

Options:
-h, --help  display help for command
```

I haven't added it to the SDK yet, we'll need to think about a good interface to simultaneously support browser and node there. The auto-generated internal API client unfortunately required a number of modifications in order to support streaming responses which are necessary for very large circuit packages. These are starting to build up, and we need to think about ways to generalize these diff patches as part of the generation process. The `openapi-typescript-codegen` codebase is unfortunately really complicated, so it's not practical to fork or patch it directly.
