### PR TITLE
Add PlonK support to the gnark project scaffold

### DIFF
--- a/sindri-manifest.json
+++ b/sindri-manifest.json
@@ -21,6 +21,12 @@
     }
   ],
   "definitions": {
+    "ZkevmVersionOptions": {
+      "title": "ZkevmVersionOptions",
+      "description": "The supported zkSync Era zkEVM version tags.",
+      "enum": ["latest", "1.4.2"],
+      "type": "string"
+    },
     "CircomCurveOptions": {
       "title": "CircomCurveOptions",
       "description": "The supported Circom curves.",
@@ -129,7 +135,7 @@
     "GnarkProvingSchemeOptions": {
       "title": "GnarkProvingSchemeOptions",
       "description": "The supported Gnark proving schemes.",
-      "enum": ["groth16"],
+      "enum": ["groth16", "plonk"],
       "type": "string"
     },
     "GnarkSindriManifest": {

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -119,10 +119,13 @@ export const initCommand = new Command()
           return true;
         },
       });
-      const provingScheme: "groth16" = await select({
+      const provingScheme: "groth16" | "plonk" = await select({
         message: "Proving Scheme:",
         default: "groth16",
-        choices: [{ name: "Groth16", value: "groth16" }],
+        choices: [
+          { name: "Groth16", value: "groth16" },
+          { name: "PlonK", value: "plonk" },
+        ],
       });
       const curveName:
         | "bn254"


### PR DESCRIPTION
This adds plonk as a proving scheme option when scaffolding out a gnark project. We just added support on the backend, so this makes it more accessible to people using `sindri init`.
