### PR TITLE
Fix multiple deploy tag handling in the CLI with an explicit project directory

### DIFF
--- a/src/cli/deploy.ts
+++ b/src/cli/deploy.ts
@@ -16,7 +16,7 @@ interface CollectedTags extends Array<string> {
   isNotDefault?: boolean;
 }
 
-function collectOptions(value: string, previous: CollectedTags): CollectedTags {
+function collectTags(value: string, previous: CollectedTags): CollectedTags {
   // The first time this function is called, `previous` will be the default `["latest"]` value
   // without `isNotDefault` set. It will only be called if at least one explicit tag was specified,
   // so we want to drop this initial default value when this happens. We track that we've already
@@ -31,7 +31,7 @@ function collectOptions(value: string, previous: CollectedTags): CollectedTags {
 export const deployCommand = new Command()
   .name("deploy")
   .description("Deploy the current Sindri project.")
-  .option("-t, --tag <tag>", "Tag to apply to the circuit.", collectOptions, [
+  .option("-t, --tag <tag>", "Tag to apply to the circuit.", collectTags, [
     "latest",
   ])
   .option("-u, --untagged", "Discard the current circuit after compiling.")


### PR DESCRIPTION
The `--tag` option on `sindri deploy` was defined as a variadic option `<tag...>` which allowed specifying multiple tags. This created a problem when the optional positional argument for the project directory was also specified because it would be interpreted as an additional tag. For example, `sindri deploy -t v1.0.0 my-circuit` would treat both `v1.0.0` and `my-circuit` as tags while using the default `.` as the project directory.

This PR fixes the handling so that you need to repeat the tag argument for each tag and the project directory is no longer consumed as a tag. So you can now do `sindri deploy -t v1.0.0 -t latest my-circuit` and have `v1.0.0` and `latest` treated as tags while `my-circuit` is the project directory.
