### PR TITLE
Trim hostname to 28 character to avoid login error with too long hostname as suggestion for API key

### DIFF
--- a/src/cli/login.ts
+++ b/src/cli/login.ts
@@ -59,7 +59,7 @@ export const loginCommand = new Command()
     const username = await input({ message: "Username:" });
     const password = await passwordInput({ mask: true, message: "Password:" });
     const name = await input({
-      default: `${os.hostname()}-sdk`,
+      default: `${os.hostname().substring(0, 28)}-sdk`,
       message: "New API Key Name:",
     });
 


### PR DESCRIPTION
## Trim hostname to 28 character to avoid login error with too long hostname as suggestion for API key

As mention in #109 