### PR TITLE
Validate API key length

### DIFF
--- a/src/cli/login.ts
+++ b/src/cli/login.ts
@@ -63,7 +63,7 @@ export const loginCommand = new Command()
       message: "New API Key Name:",
       validate: (input) => {
         if (input.length > 32) {
-          return "API key name must 32 characters or less.";
+          return "API key name must 32 characters or fewer.";
         }
         return true;
       },

--- a/src/cli/login.ts
+++ b/src/cli/login.ts
@@ -61,6 +61,12 @@ export const loginCommand = new Command()
     const name = await input({
       default: `${os.hostname().substring(0, 28)}-sdk`,
       message: "New API Key Name:",
+      validate: (input) => {
+        if (input.length > 32) {
+          return "API key name must 32 characters or less.";
+        }
+        return true;
+      },
     });
 
     // Generate an API key for one of their teams.


### PR DESCRIPTION
We collect an API key name during `sindri login` and the backend only supports a maximum length of 32. This PR adds a simple input validator for the field that displays an "API key name must 32 characters or fewer" error message and allows the user to modify the input and try again. Previously they would have gotten a fatal API error requiring them to start over and re-enter their credentials.

Connects #109
