### PR TITLE
Add new Halo2 and Noir versions to the sindri manifest schema

### DIFF
--- a/sindri-manifest.json
+++ b/sindri-manifest.json
@@ -17,6 +17,9 @@
       "$ref": "#/definitions/Halo2AxiomV030SindriManifest"
     },
     {
+      "$ref": "#/definitions/Halo2PSEV030SindriManifest"
+    },
+    {
       "$ref": "#/definitions/NoirSindriManifest"
     }
   ],
@@ -24,7 +27,7 @@
     "ZkevmVersionOptions": {
       "title": "ZkevmVersionOptions",
       "description": "The supported zkSync Era zkEVM version tags.",
-      "enum": ["latest", "1.4.2"],
+      "enum": ["latest", "1.4.2", "1.5.0"],
       "type": "string"
     },
     "CircomCurveOptions": {
@@ -408,6 +411,91 @@
       ],
       "additionalProperties": false
     },
+    "Halo2PSEV030SindriManifest": {
+      "title": "Sindri Manifest for PSE v0.3.0 Halo2 Circuits",
+      "description": "Sindri Manifest for PSE v0.3.0 circuits built with the Halo2 framework.",
+      "type": "object",
+      "properties": {
+        "circuitType": {
+          "title": "Circuit Type",
+          "description": "The (frontend) development framework that your circuit is written with.",
+          "enum": ["halo2"],
+          "type": "string"
+        },
+        "name": {
+          "title": "Circuit Name",
+          "description": "The circuit name used to uniquely identify the circuit within your organization. Similar to a GitHub project name or a Docker image name.",
+          "pattern": "^[a-zA-Z0-9_-]+$",
+          "error_messages": {
+            "regex": "`name` must be a valid slug."
+          },
+          "type": "string"
+        },
+        "curve": {
+          "title": "Proving Curve",
+          "description": "The curve over which the proof is executed.",
+          "default": "bn254",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Halo2CurveOptions"
+            }
+          ]
+        },
+        "className": {
+          "title": "Circuit Class Name",
+          "description": "The path to your circuit struct definition. (*e.g.* `my-package::my_file::MyCircuitStruct`).",
+          "pattern": "^([A-Za-z_][A-Za-z0-9_]*::)+[A-Za-z_][A-Za-z0-9_]*$",
+          "error_messages": {
+            "regex": "`className` must be a valid and fully qualifed Rust path to a struct including the crate name."
+          },
+          "type": "string"
+        },
+        "degree": {
+          "title": "Degree",
+          "description": "Specifies that the circuit will have 2^degree rows.",
+          "type": "integer"
+        },
+        "halo2Version": {
+          "title": "Halo2 Version",
+          "description": "The Halo2 frontend that your circuit is written with.",
+          "enum": ["pse-v0.3.0"],
+          "type": "string"
+        },
+        "packageName": {
+          "title": "Rust Package Name",
+          "description": "The name of the Rust package containing your circuit.",
+          "pattern": "^[a-z0-9_]+(?:-[a-z0-9_]+)*$",
+          "error_messages": {
+            "regex": "`packageName` must be a valid Rust crate name."
+          },
+          "type": "string"
+        },
+        "provingScheme": {
+          "description": "The backend proving scheme.",
+          "default": "shplonk",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Halo2ProvingSchemeOptions"
+            }
+          ]
+        },
+        "$schema": {
+          "type": "string",
+          "title": "Sindri Manifest JSON Schema URL",
+          "description": "The URL pointing to a Sindri JSON Manifest schema definition.",
+          "examples": ["https://sindri.app/api/v1/sindri-manifest-schema.json"]
+        }
+      },
+      "required": [
+        "circuitType",
+        "name",
+        "className",
+        "degree",
+        "halo2Version",
+        "packageName"
+      ],
+      "additionalProperties": false
+    },
     "NoirCurveOptions": {
       "title": "NoirCurveOptions",
       "description": "The supported Noir curves.",
@@ -423,7 +511,19 @@
     "NoirVersionOptions": {
       "title": "NoirVersionOptions",
       "description": "The supported Noir Compiler and Prover versions.",
-      "enum": ["latest", "0.17.0", "0.18.0", "0.19.4", "0.22.0", "0.23.0"],
+      "enum": [
+        "latest",
+        "0.17.0",
+        "0.18.0",
+        "0.19.4",
+        "0.22.0",
+        "0.23.0",
+        "0.24.0",
+        "0.25.0",
+        "0.26.0",
+        "0.27.0",
+        "0.28.0"
+      ],
       "type": "string"
     },
     "NoirSindriManifest": {


### PR DESCRIPTION
This adds the new Noir v.24.0-v.28.0 versions and Halo2 PSE v0.3.0. It also bumps the zksync VM version tags which I think we actually want to filter out from the schema, but that can be done as a followup.
