### PR TITLE
Set default circomspect library paths when versions allow

### DIFF
--- a/src/cli/lint.ts
+++ b/src/cli/lint.ts
@@ -212,8 +212,8 @@ export const lintCommand = new Command()
           );
           const libraryPathSupported: boolean =
             libraryPathSupportedTestCode === 0;
-          // Conditionally include library paths if supported by the ciromspect version.
-          // It's important that this backend logic is kept in sync with the backend.
+          // Conditionally include library paths if supported by the Ciromspect version.
+          // It's important that this path logic is kept in sync with the Sindri backend.
           const libraryPathArgs: string[] = libraryPathSupported
             ? ["--library", ".", "--library", path.join(".", "node_modules")]
             : [];

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -32,6 +32,7 @@ const currentDirectoryPath = path.dirname(currentFilePath);
  */
 export function checkCommandExists(command: string): Promise<boolean> {
   return new Promise((resolve) => {
+    // TODO: Circomspect doesn't support this argument, so this will always fail for that command.
     const process = spawn(command, ["--version"]);
 
     process.on("error", () => {

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -130,7 +130,10 @@ export async function execCommand(
         `"${process.env.SINDRI_FORCE_DOCKER}".`,
     );
   } else if (await checkCommandExists(command)) {
-    logger?.debug(`Executing the "${command}" command locally.`);
+    logger?.debug(
+      { args, command },
+      `Executing the "${command}" command locally.`,
+    );
     return {
       code: await execLocalCommand(command, args, { cwd, logger, tty }),
       method: "local",
@@ -143,7 +146,10 @@ export async function execCommand(
 
   // Fall back to using Docker if possible.
   if (await checkDockerAvailability(logger)) {
-    logger?.debug(`Executing the "${command}" command in a Docker container.`);
+    logger?.debug(
+      { args, command },
+      `Executing the "${command}" command in a Docker container.`,
+    );
     return {
       code: await execDockerCommand(command, args, {
         cwd,


### PR DESCRIPTION
Circomspect added support for a `-L`/`--library` search path flag in analogy to Circom's `-l` argument (as of trailofbits/circomspect#21) that we use on the backend with defaults of the project root and the `node_modules` subdirectory. This PR updates the `sindri lint` command to check whether the current Circomspect version supports the argument, and then to specify the same search paths if the argument is supported. We'll probably end up making the search paths configurable, but this makes the backend consistent with `sindri lint` in the meantime.

For testing it manually, you can run

```bash
docker compose up -d
docker compose exec sindri-js bash
```

on the latest branch, change into a directory with one of our example Circom circuits that has been failing linting, and then run:

```bash
sindri lint
```

to make sure that things work as expected.
