### PR TITLE
Allow disabling Circomspect in `sindri lint`

### DIFF
--- a/src/cli/lint.ts
+++ b/src/cli/lint.ts
@@ -12,6 +12,7 @@ import type { Log as SarifLog, Result as SarifResult } from "sarif";
 import {
   execCommand,
   findFileUpwards,
+  isTruthy,
   loadSindriManifestJsonSchema,
 } from "cli/utils";
 import sindri from "lib";
@@ -186,8 +187,16 @@ export const lintCommand = new Command()
       sindri.logger.debug(`README file found at "${readmePath}".`);
     }
 
-    // Run Circomspect for Circom circuits.
-    if (circuitType === "circom") {
+    // Run Circomspect for Circom circuits, unless it's been disabled.
+    if (
+      circuitType === "circom" &&
+      isTruthy(process.env.SINDRI_LINT_DISABLE_CIRCOMSPECT ?? "false")
+    ) {
+      sindri.logger.warn(
+        "Skipping Circomspect static analysis because " +
+          `"SINDRI_LINT_DISABLE_CIRCOMSPECT=${process.env.SINDRI_LINT_DISABLE_CIRCOMSPECT}".`,
+      );
+    } else if (circuitType === "circom") {
       try {
         // Run Circomspect and parse the results.
         sindri.logger.info(


### PR DESCRIPTION
This adds support for disabling Circomspect static analysis in the `sindri lint` command by setting the `SINDRI_LINT_DISABLE_CIRCOMSPECT` environment variable to `true`. This is primarily motivated by internal use-cases where we want to check the Sindri manifest schema of test circuits which deliberately have other issues, so I don't think it's necessary that we document it at this point. As we start adding more options like this, we probably should give some thought to documentation.

### Manual Testing

```bash
docker compose up -d
docker compose exec sindri-js bash
cd /path/to/circom/circuit/  # Change me.

# Should output Circomspect info.
sindri -d lint
# Should output a warning about not running Circomspect.
SINDRI_LINT_DISABLE_CIRCOMSPECT=true sindri -d lint
```