### PR TITLE
Add request retries to `SindriClient`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "@commander-js/extra-typings": "^11.1.0",
+        "@fullstax/p-retry": "^6.2.0-patch.4",
         "@inquirer/prompts": "^3.3.0",
         "@tsconfig/node18": "^18.2.2",
         "@types/gzip-js": "^0.3.5",
@@ -37,6 +38,7 @@
         "pino-pretty": "^10.2.3",
         "postinstall-postinstall": "^2.1.0",
         "rc": "^1.2.8",
+        "retry": "^0.13.1",
         "tar": "^6.2.0",
         "tar-js": "^0.3.0",
         "zod": "^3.22.4"
@@ -661,6 +663,33 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fullstax/is-network-error": {
+      "version": "1.1.0-patch.2",
+      "resolved": "https://registry.npmjs.org/@fullstax/is-network-error/-/is-network-error-1.1.0-patch.2.tgz",
+      "integrity": "sha512-hfOpo2XUngzQFCdkK8wz3vugi+HgmdzHkBZSv2epL/zaCP/nQ4/Ydz5raJ4bobxmRcAE8tydoykBJOhEbF4S5A==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@fullstax/p-retry": {
+      "version": "6.2.0-patch.4",
+      "resolved": "https://registry.npmjs.org/@fullstax/p-retry/-/p-retry-6.2.0-patch.4.tgz",
+      "integrity": "sha512-UCCxkDvUbCKitAkC0FK4uE3u4owBa5CzwISeQBMCrZJZcsqPdpt3iR2+ZXQOvZW4jJrfWYTJGUVysAba7nOtmw==",
+      "dependencies": {
+        "@fullstax/is-network-error": "^1.1.0-patch.2",
+        "@types/retry": "0.12.2",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1466,6 +1495,11 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+      "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow=="
     },
     "node_modules/@types/sarif": {
       "version": "2.1.7",
@@ -6420,6 +6454,14 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/reusify": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
   "homepage": "https://github.com/Sindri-Labs/sindri-js#readme",
   "dependencies": {
     "@commander-js/extra-typings": "^11.1.0",
+    "@fullstax/p-retry": "^6.2.0-patch.4",
     "@inquirer/prompts": "^3.3.0",
     "@tsconfig/node18": "^18.2.2",
     "@types/gzip-js": "^0.3.5",
@@ -102,6 +103,7 @@
     "pino-pretty": "^10.2.3",
     "postinstall-postinstall": "^2.1.0",
     "rc": "^1.2.8",
+    "retry": "^0.13.1",
     "tar": "^6.2.0",
     "tar-js": "^0.3.0",
     "zod": "^3.22.4"

--- a/src/lib/api/core/OpenAPI.ts
+++ b/src/lib/api/core/OpenAPI.ts
@@ -2,7 +2,7 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-import type { Logger } from "lib/logging"; // DO NOT REMOVE
+import type { SindriClient } from "lib/client"; // DO NOT REMOVE
 
 import type { ApiRequestOptions } from "./ApiRequestOptions";
 
@@ -20,9 +20,9 @@ export type OpenAPIConfig = {
   HEADERS?: Headers | Resolver<Headers> | undefined;
   ENCODE_PATH?: ((path: string) => string) | undefined;
   // DO NOT REMOVE
-  // Shoehorn the logger into the OpenAPIConfig type because it's the only shared data structure
-  // between the SDK client class and the request methods `requests.ts` module.
-  logger?: Logger; // DO NOT REMOVE
+  // Shoehorn the SindriClient instance into the OpenAPIConfig type because it's the only shared
+  // data structure between the SDK client class and the request methods `requests.ts` module.
+  sindri?: SindriClient; // DO NOT REMOVE
 };
 
 export const OpenAPI: OpenAPIConfig = {

--- a/src/lib/api/core/request.ts
+++ b/src/lib/api/core/request.ts
@@ -274,7 +274,7 @@ export const sendRequest = async <T>(
     if (!config.sindri) {
       return await axiosClient.request(requestConfig);
     }
-    return pRetry(() => axiosClient.request(requestConfig), {
+    return await pRetry(() => axiosClient.request(requestConfig), {
       ...config.sindri.retryOptions,
       onFailedAttempt: (error) => {
         // Don't log anything if we're not going to retry the request, the error will get logged

--- a/src/lib/api/core/request.ts
+++ b/src/lib/api/core/request.ts
@@ -367,7 +367,7 @@ export const request = <T>(
       const headers = await getHeaders(config, options, formData);
 
       if (!onCancel.isCancelled) {
-        config.logger?.debug(`${logPrefix} requested`);
+        config.sindri?.logger.debug(`${logPrefix} requested`);
         const response = await sendRequest<T>(
           config,
           options,
@@ -395,15 +395,17 @@ export const request = <T>(
           response.statusText
         } (${getElapsedTime()})`;
         if (!result.body || typeof result.body === "string") {
-          config.logger?.debug(
+          config.sindri?.logger.debug(
             `${responseMessage} - ${result.body || "<empty-body>"}`,
           );
         } else if (options.responseType === "stream") {
-          config.logger?.debug(`${responseMessage} - <streaming-response>`);
+          config.sindri?.logger.debug(
+            `${responseMessage} - <streaming-response>`,
+          );
         } else if (options.responseType === "blob") {
-          config.logger?.debug(`${responseMessage} - <blob-response>`);
+          config.sindri?.logger.debug(`${responseMessage} - <blob-response>`);
         } else {
-          config.logger?.debug(result.body, responseMessage);
+          config.sindri?.logger.debug(result.body, responseMessage);
         }
 
         catchErrorCodes(options, result);
@@ -413,7 +415,7 @@ export const request = <T>(
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : "Unknown error";
-      config.logger?.debug(
+      config.sindri?.logger.debug(
         `${logPrefix} ERROR (${getElapsedTime()}) - ${errorMessage}`,
       );
       reject(error);

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -115,13 +115,10 @@ export class SindriClient {
    * Represents the options for retrying requests to the Sindri ZKP service.
    *
    * See the [`retry` package](https://www.npmjs.com/package/retry#retrytimeoutsoptions)
-   * documentation for more information on the available options.
+   * documentation for more information on the available options. The values here are the defaults,
+   * but they can be replaced with custom values in the constructor.
    */
-  public retryOptions: RetryOptions;
-  /**
-   * The default retry options that will be used for the client if none are provided.
-   */
-  static readonly defaultRetryOptions: RetryOptions = {
+  public retryOptions: RetryOptions = {
     minTimeout: 1000,
     retries: 4,
   };
@@ -145,9 +142,7 @@ export class SindriClient {
    */
   constructor(
     authOptions: AuthOptions = {},
-    { retryOptions }: { retryOptions: RetryOptions } = {
-      retryOptions: SindriClient.defaultRetryOptions,
-    },
+    { retryOptions }: { retryOptions?: RetryOptions } = {},
   ) {
     // Initialize the client and store a reference to its config.
     this._client = new ApiClient();
@@ -173,7 +168,9 @@ export class SindriClient {
     this.authorize(authOptions);
 
     // Store the retry options.
-    this.retryOptions = structuredClone(retryOptions);
+    if (retryOptions) {
+      this.retryOptions = structuredClone(retryOptions);
+    }
   }
 
   /**
@@ -302,6 +299,8 @@ export class SindriClient {
    *
    * @param authOptions - The authentication options for the client, including
    * credentials like API keys or tokens. Defaults to an empty object if not provided.
+   * @param options - Additional options for configuring the client.
+   * @param options.retryOptions - The options related to retrying a request.
    *
    * @example
    * import sindri from 'sindri';
@@ -311,8 +310,15 @@ export class SindriClient {
    *
    * @returns The new client instance.
    */
-  create(authOptions: AuthOptions | undefined): SindriClient {
-    return new SindriClient(authOptions);
+  create(
+    authOptions: AuthOptions | undefined,
+    options:
+      | {
+          retryOptions?: RetryOptions;
+        }
+      | undefined,
+  ): SindriClient {
+    return new SindriClient(authOptions, options);
   }
 
   /**

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -120,7 +120,7 @@ export class SindriClient {
    */
   public retryOptions: RetryOptions = {
     minTimeout: 1000,
-    retries: 4,
+    retries: 6,
   };
 
   /**

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -146,7 +146,7 @@ export class SindriClient {
     if (!process.env.BROWSER_BUILD) {
       this._config = new Config(this.logger);
     }
-    this._clientConfig.logger = this.logger;
+    this._clientConfig.sindri = this;
 
     // Authorize the client.
     this.authorize(authOptions);


### PR DESCRIPTION
This adds a second argument to the `SindriClient()` constructor which can include a `retryOptions` field which controls the newly added retry behavior. The options are passed through to the `retry` package and are documented [here](https://www.npmjs.com/package/retry#retrytimeoutsoptions). By default, we'll retry 4 times with exponential backoff starting at a 1000 ms timeout. The logic to determine whether to retry is hard-coded, we retry for status codes of 502-504 or any sort of connection errors.

Note that we use a fork of `p-retry` here which supports both ESM and CJS because we provide builds for each in our package (see: sindresorhus/p-retry/issues/76).

Closes #118
