### PR TITLE
Fix `sindri clone` command

### DIFF
--- a/src/lib/api/services/InternalService.ts
+++ b/src/lib/api/services/InternalService.ts
@@ -61,6 +61,8 @@ export class InternalService {
         404: `Not Found`,
         500: `Internal Server Error`,
       },
+
+      responseType: process.env.BROWSER_BUILD ? "blob" : "stream", // DO NOT REMOVE
     });
   }
 
@@ -307,7 +309,6 @@ export class InternalService {
         422: `Unprocessable Entity`,
         500: `Internal Server Error`,
       },
-      responseType: process.env.BROWSER_BUILD ? "blob" : "stream", // DO NOT REMOVE
     });
   }
 


### PR DESCRIPTION
The regeneration of the internal API client in #123 inadvertently moved the `responseType: 'blob'` on `circuitDownload` to `projectSettings`. This broke the `sindri clone` command in `v0.0.1-alpha.53`. This PR moves it back to where it should be.

Connects #123
Connects #126
