### PR TITLE
Allow stage/dev servers when recording tests with `useNock()`

### DIFF
--- a/test/utils/useNock.ts
+++ b/test/utils/useNock.ts
@@ -22,7 +22,13 @@ export const useNock = async () => {
   test.before(async (t: ExecutionContext<Context>) => {
     // Start recording, and only allow connections to `sindri.app`.
     nock.disableNetConnect();
-    nock.enableNetConnect("sindri.app");
+    // We allow three sources here:
+    // * https://localhost.run/'s https://*.lhr.life for development.
+    // * https://ngrok.com/ for development.
+    // * https://sindri.app/ for production, stage, and development.
+    nock.enableNetConnect(
+      /^(https?:\/\/)?(.+\.)?(lhr\.life|ngrok-free.app|sindri.app)(:\d+)?$/i,
+    );
     nockBack.setMode((process.env.NOCK_BACK_MODE ?? "lockdown") as BackMode);
     const { nockDone } = await nockBack(fixtureFilename, {
       before: matchFormPayloads,


### PR DESCRIPTION
We made stage/dev API servers allowed in `usePage()` in #128. This updates `useNock()` to make the same allowances.
