### PR TITLE
Make the test timeout configurable

### DIFF
--- a/ava.config.mjs
+++ b/ava.config.mjs
@@ -7,17 +7,33 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 process.env.TSX_TSCONFIG_PATH = path.join(__dirname, "tsconfig.test.json");
 
+let timeout;
+if (process.env.TEST_TIMEOUT) {
+  // Allow the timeout to be specified with the `TEST_TIMEOUT` environment variable.
+  timeout = process.env.TEST_TIMEOUT;
+  // Default to seconds if no unit is specified.
+  if (/^\d+$/.test(timeout)) {
+    timeout = `${timeout}s`;
+  }
+} else {
+  // Set the default fallback timeout and increase it if we expect to make live API calls.
+  if (
+    ["dryrun", "record", "update", "wild"].includes(
+      process.env.NOCK_BACK_MODE ?? "lockdown",
+    )
+  ) {
+    timeout = "10m";
+  } else {
+    timeout = "60s";
+  }
+}
+
 export default {
   extensions: {
     ts: "module",
   },
   files: ["test/**/*.test.ts"],
-  // Increase the timeout if we expect to make live API calls.
-  timeout: ["dryrun", "record", "update", "wild"].includes(
-    process.env.NOCK_BACK_MODE ?? "lockdown",
-  )
-    ? "240s"
-    : "60s",
+  timeout,
   // Use child processes instead of threads because notch isn't thread safe.
   workerThreads: false,
 };


### PR DESCRIPTION
The test timeouts were previously hardcoded to 60s for playback tests and 240s while recording. Recording the tests has been takes ~5 minutes on CI and bumping into this timeout. This PR updates the default while recording to 10 minutes and makes it configurable with a `TEST_TIMEOUT` environment variable. If `TEST_TIMEOUT` is a raw number, the units will be assumed to be seconds. You can also specify a units suffix like `TEST_TIMEOUT=10m`.

To test this locally, you can enter the compose container and run:

```bash
# Make sure you have credentials first.
sindri login

# Should fail because it times out.
TEST_TIMEOUT=5s npm run test:record

# Should both run to completion.
TEST_TIMEOUT=10m npm run test:record
npm run test:record
```