### PR TITLE
Block Google telemetry in browser tests

### DIFF
--- a/test/browser.test.ts
+++ b/test/browser.test.ts
@@ -29,6 +29,28 @@ test("library is injected and authorized", async (t) => {
   t.truthy(baseUrl);
 });
 
+test("access to google.com is blocked", async (t) => {
+  const status: number | null = await t.context.page.evaluate(async () => {
+    sindri._clientConfig.BASE = "https://accounts.google.com";
+    try {
+      const response: { status: number } = await sindri._client.request.request(
+        {
+          method: "GET",
+          url: "/ListAccounts",
+        },
+      );
+      return response?.status ?? null;
+    } catch (error) {
+      return (error as { status: number })?.status ?? null;
+    }
+  });
+  t.deepEqual(
+    status,
+    500,
+    "Requests to google.com delays should be blocked with a 500 status code.",
+  );
+});
+
 test("create circuit from file array", async (t) => {
   const circuitDirectory = path.join(dataDirectory, "circom-multiplier2");
   const fileNames = await fs.readdir(circuitDirectory);

--- a/test/browser.test.ts
+++ b/test/browser.test.ts
@@ -30,7 +30,10 @@ test("library is injected and authorized", async (t) => {
 });
 
 test("access to google.com is blocked", async (t) => {
+  // Squash Chrome's error logging for this page, we expect a 403 error.
+  t.context.page.removeAllListeners("console");
   const status: number | null = await t.context.page.evaluate(async () => {
+    // Hackily use the sindri's internal client to make a request to Google.
     sindri._clientConfig.BASE = "https://accounts.google.com";
     try {
       const response: { status: number } = await sindri._client.request.request(
@@ -46,8 +49,8 @@ test("access to google.com is blocked", async (t) => {
   });
   t.deepEqual(
     status,
-    500,
-    "Requests to google.com delays should be blocked with a 500 status code.",
+    403,
+    "Requests to google.com delays should be blocked with a 403 status code.",
   );
 });
 

--- a/test/utils/usePage.ts
+++ b/test/utils/usePage.ts
@@ -36,13 +36,11 @@ function createProxy(): Proxy {
   proxy.onRequest((ctx, callback) => {
     const host = ctx.clientToProxyRequest.headers.host ?? "";
     if (/(^|.).google.com/i.test(host)) {
-      // Return 500 errors for any Google requests.
-      ctx.proxyToClientResponse.writeHead(500, {
+      // Return 403 errors for any Google requests.
+      ctx.proxyToClientResponse.writeHead(403, {
         "Content-Type": "text/plain",
       });
-      ctx.proxyToClientResponse.end(
-        "Internal Server Error: Blocked Google Services",
-      );
+      ctx.proxyToClientResponse.end("Bad Request: Google Services Blocked");
     } else {
       // Continue processing the request normally if it's not Google.
       return callback();

--- a/test/utils/usePage.ts
+++ b/test/utils/usePage.ts
@@ -32,6 +32,23 @@ function createProxy(): Proxy {
   const proxy = new Proxy();
   proxy.use(Proxy.wildcard);
 
+  // Block Google phoning home.
+  proxy.onRequest((ctx, callback) => {
+    const host = ctx.clientToProxyRequest.headers.host ?? "";
+    if (/(^|.).google.com/i.test(host)) {
+      // Return 500 errors for any Google requests.
+      ctx.proxyToClientResponse.writeHead(500, {
+        "Content-Type": "text/plain",
+      });
+      ctx.proxyToClientResponse.end(
+        "Internal Server Error: Blocked Google Services",
+      );
+    } else {
+      // Continue processing the request normally if it's not Google.
+      return callback();
+    }
+  });
+
   // The library uses `console.debug()` a lot and it's noisy.
   console.debug = () => {};
 


### PR DESCRIPTION
Earlier Puppeteer/Chromium versions weren't phoning home to Google, but this appears to have changed after #145. This updates are proxy configuration to return 403s for any Google URLs which keeps them out of the test fixtures and makes things more predictable. A browser test has been added which verifies this behavior.

Connects #145
