### PR TITLE
Properly surface non-serializable errors in tests

### DIFF
--- a/ava.config.mjs
+++ b/ava.config.mjs
@@ -33,6 +33,7 @@ export default {
     ts: "module",
   },
   files: ["test/**/*.test.ts"],
+  require: ["test/utils/makeAxiosErrorsSerializable.ts"],
   timeout,
   // Use child processes instead of threads because notch isn't thread safe.
   workerThreads: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
         "prettier": "^3.1.0",
         "puppeteer": "^23.2.1",
         "rollup": "^4.9.5",
+        "serialize-error": "^12.0.0",
         "sharp": "^0.33.5",
         "tsup": "^7.3.0",
         "tsx": "^4.7.0",
@@ -7276,27 +7277,15 @@
       }
     },
     "node_modules/serialize-error": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
-      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-12.0.0.tgz",
+      "integrity": "sha512-ZYkZLAvKTKQXWuh5XpBw7CdbSzagarX39WyZ2H07CDLC5/KfsRGlIXV8d4+tfqX1M7916mRqR1QfNHSij+c9Pw==",
       "dev": true,
       "dependencies": {
-        "type-fest": "^0.13.1"
+        "type-fest": "^4.31.0"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/serialize-error/node_modules/type-fest": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7839,6 +7828,21 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/supertap/node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/supertap/node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -7858,6 +7862,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/supertap/node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/supports-color": {
@@ -8361,9 +8377,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.14.0.tgz",
-      "integrity": "sha512-on5/Cw89wwqGZQu+yWO0gGMGu8VNxsaW9SB2HE8yJjllEk7IDTwnSN1dUVldYILhYPN5HzD7WAaw2cc/jBfn0Q==",
+      "version": "4.37.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.37.0.tgz",
+      "integrity": "sha512-S/5/0kFftkq27FPNye0XM1e2NsnoD/3FS+pBmbjmmtLT6I+i344KoOf7pvXreaFsDamWeaJX55nczA1m5PsBDg==",
       "dev": true,
       "engines": {
         "node": ">=16"

--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "prettier": "^3.1.0",
     "puppeteer": "^23.2.1",
     "rollup": "^4.9.5",
+    "serialize-error": "^12.0.0",
     "sharp": "^0.33.5",
     "tsup": "^7.3.0",
     "tsx": "^4.7.0",

--- a/test/utils/makeAxiosErrorsSerializable.ts
+++ b/test/utils/makeAxiosErrorsSerializable.ts
@@ -1,0 +1,30 @@
+import axios from "axios";
+import { serializeError, deserializeError } from "serialize-error";
+
+/**
+ * Make an error object serializable.
+ *
+ * The heavy lifting is done by the `serialize-error` package, which handles functions, buffers,
+ * circular references, and other things that would make errors non-serializable. We simply do a
+ * round trip through serialization and deserialization to ensure that the error is clean.
+ */
+function sanitizeError(error: Error): Error {
+  return deserializeError(serializeError(error));
+}
+
+/**
+ * Patch Axios to remove functions from the request config.
+ *
+ * When Ava tries to serialize axios errors to send IPC messages from the test workers to the main
+ * process, it fails because the error object contains functions. This patch removes any functions
+ * so that the errors can be serialized. The Ava test config is setup to automatically load and run
+ * this patch in the test workers.
+ */
+export function patchAxios() {
+  axios.interceptors.response.use(
+    (response) => response,
+    (error) => Promise.reject(sanitizeError(error)),
+  );
+}
+
+export default patchAxios;

--- a/test/utils/makeAxiosErrorsSerializable.ts
+++ b/test/utils/makeAxiosErrorsSerializable.ts
@@ -20,11 +20,11 @@ function sanitizeError(error: Error): Error {
  * so that the errors can be serialized. The Ava test config is setup to automatically load and run
  * this patch in the test workers.
  */
-export function patchAxios() {
+export function makeAxiosErrorsSerializable() {
   axios.interceptors.response.use(
     (response) => response,
     (error) => Promise.reject(sanitizeError(error)),
   );
 }
 
-export default patchAxios;
+export default makeAxiosErrorsSerializable;


### PR DESCRIPTION
AVA runs tests in separate processes, and it uses IPC to communicate them back to the main process for logging and reporting. If an error isn't serializable, then the IPC fails and we end up not being able to see the actual error or even what test failed which is as delightful as it sounds. The main culprit of this has been Axios when there's a Nock error.

This PR improves the situation by adding an Axios response interceptor and sanitizing any errors so that they're serializable. The heavy lifting on the sanitization is done by the serialize-error package which I've added as a dev dependency. It cleans up issues like functions, buffers, and circular references which are the common culprits of non-serializability.

If you want to test this yourself, you can remove fixtures with `rm test/fixtures/sdk.test.ts.json` and then run `npm run test` to run the tests. You'll get the opaque error on `main` and the real error on this branch.
