### PR TITLE
Add a command to build without type generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "scripts": {
     "build": "rm -rf dist/* && NODE_ENV=production tsup",
+    "build:no-types": "export TSUP_DTS=false && npm run build",
     "build:watch": "rm -rf dist/* && NODE_ENV=development tsup --watch",
     "download-sindri-manifest-schema": "export SINDRI_BASE_URL=${SINDRI_BASE_URL:-https://sindri.app} && nwget ${SINDRI_BASE_URL:-https://sindri.app}/api/v1/sindri-manifest-schema.json -O sindri-manifest.json && sed -i -E 's#\"https?://[^/]+/api/#\\\"https://sindri.app/api/#g' sindri-manifest.json && prettier --write sindri-manifest.json",
     "download-sindri-manifest-schema:dev": "export SINDRI_BASE_URL=http://localhost:8000 && npm run download-sindri-manifest-schema",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "test": "npm run build && npm run test:fast",
     "test:fast": "tsx ./node_modules/.bin/ava",
     "test:record": "NOCK_BACK_MODE=update npm run test",
+    "test:record:fast": "export NOCK_BACK_MODE=update && npm run test:fast",
     "test:watch": "NODE_ENV=development NOCK_BACK_MODE=dryrun nodemon --watch src/ --watch test/ --ext js,cjs,mjs,ts,cts,mts --exec 'tsup --silent && tsx ./node_modules/.bin/ava'",
     "type-check": "tsc --noEmit",
     "/***** Hooks *****/": "",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -3,12 +3,13 @@ import { defineConfig } from "tsup";
 
 process.env.NODE_ENV = process.env.NODE_ENV || "production";
 process.env.VERSION = process.env.VERSION || "0.0.0";
+const dts = (process.env.TSUP_DTS ?? "true") !== "false";
 
 export default defineConfig([
   // SDK for NodeJS.
   {
     cjsInterop: true,
-    dts: true,
+    dts,
     entry: ["src/lib/index.ts"],
     env: {
       NODE_ENV: process.env.NODE_ENV,
@@ -26,7 +27,7 @@ export default defineConfig([
   },
   // SDK for Browser.
   {
-    dts: true,
+    dts,
     entry: ["src/lib/index.ts"],
     env: {
       BROWSER_BUILD: "true",
@@ -62,7 +63,7 @@ export default defineConfig([
   // CLI Tool.
   {
     bundle: true,
-    dts: true,
+    dts,
     entry: ["src/cli/index.ts"],
     env: {
       NODE_ENV: process.env.NODE_ENV,


### PR DESCRIPTION
Our tsup config was previously hard-coded to always emit types, so builds would fail if the types were invalid. This PR updates things so you can do `npm run build:no-types` to skip type generation, and also adds an `npm run test:record:fast` so that you can record test fixtures without performing a build. These will be used to improve the handling of type errors in our automatic update PRs.
