### PR TITLE
Fix team selection in `sindri login` command

### DIFF
--- a/src/cli/login.ts
+++ b/src/cli/login.ts
@@ -94,15 +94,14 @@ export const loginCommand = new Command()
       }
 
       // Generate an API key.
-      sindri._clientConfig.HEADERS = {
-        ...sindri._clientConfig.HEADERS,
-        "Sindri-Team-Id": `${teamId}`,
-      };
-      const apiKeyResult = await sindri._client.authorization.apikeyGenerate({
-        username,
-        password,
-        name,
-      });
+      const apiKeyResult = await sindri._client.authorization.apikeyGenerate(
+        {
+          username,
+          password,
+          name,
+        },
+        `${teamId}`,
+      );
       const apiKey = apiKeyResult.api_key;
       const apiKeyId = apiKeyResult.id;
       const apiKeyName = apiKeyResult.name;


### PR DESCRIPTION
The API key generation endpoint schema changed recently to explicitly include a `Sindri-Team-Id` header. The actual endpoint behavior didn't change, but the OpenAPI schema change caused an explicit `sindriTeamId` argument to be added to `apikeyGenerate()` in the client, and the default value of `null` was overriding the header that we were setting explicitly in the `sindri login` command. This caused all API key generation to default to a user's personal team regardless of the team they selected. This PR updates `sindri login` to use the new `sindriTeamId` argument.
