### PR TITLE
Disable the GPU in the browser tests

### DIFF
--- a/test/utils/usePage.ts
+++ b/test/utils/usePage.ts
@@ -117,6 +117,9 @@ export const usePage = async ({
         `--proxy-server=http://localhost:${proxyPort}`,
         // Disable CORS because they don't play back correctly with Nock and the proxy.
         "--disable-web-security",
+	// Disable GPU to address protocol timeouts on CI. See:
+	// * https://github.com/puppeteer/puppeteer/issues/12637#issuecomment-2264825922
+	"--disable-gpu",
       ],
     });
 

--- a/test/utils/usePage.ts
+++ b/test/utils/usePage.ts
@@ -117,9 +117,9 @@ export const usePage = async ({
         `--proxy-server=http://localhost:${proxyPort}`,
         // Disable CORS because they don't play back correctly with Nock and the proxy.
         "--disable-web-security",
-	// Disable GPU to address protocol timeouts on CI. See:
-	// * https://github.com/puppeteer/puppeteer/issues/12637#issuecomment-2264825922
-	"--disable-gpu",
+        // Disable GPU to address protocol timeouts on CI. See:
+        // * https://github.com/puppeteer/puppeteer/issues/12637#issuecomment-2264825922
+        "--disable-gpu",
       ],
     });
 


### PR DESCRIPTION
We've been getting this error intermittently on some of our CI runners:

```
ProtocolError {
  message: 'Runtime.callFunctionOn timed out. Increase the \'protocolTimeout\' setting in launch/connect calls for a higher timeout if needed.',
  name: 'ProtocolError',
}
```

Some others have reported getting around this by disabling the GPU (see: https://github.com/puppeteer/puppeteer/issues/12637#issuecomment-2264825922). This PR gives that a shot and we'll see if the issues disappear.
