### PR TITLE
Fix Typo in Comment: "referecnes" to "references" in import.test.ts

### DIFF
--- a/test/import.test.ts
+++ b/test/import.test.ts
@@ -20,7 +20,7 @@ const requireCjs = async (
     // Necessary for the browser tests.
     global.window = {};
 
-    // Use flatted for better handling of non-JSON content, circular referecnes, etc.
+    // Use flatted for better handling of non-JSON content, circular references, etc.
     const { stringify } = require("flatted");
 
     const module = require("${moduleFullPath}");


### PR DESCRIPTION


Description:  
This pull request corrects a typo in the comment within the test/import.test.ts file. The word "referecnes" has been updated to "references" for better clarity and accuracy. No functional code changes were made; this is purely a documentation/comment fix.
