### PR TITLE
Extend test and puppeteer protocol timeouts to 30 minutes

### DIFF
--- a/ava.config.mjs
+++ b/ava.config.mjs
@@ -22,7 +22,7 @@ if (process.env.TEST_TIMEOUT) {
       process.env.NOCK_BACK_MODE ?? "lockdown",
     )
   ) {
-    timeout = "10m";
+    timeout = "30m";
   } else {
     timeout = "60s";
   }

--- a/test/utils/usePage.ts
+++ b/test/utils/usePage.ts
@@ -121,6 +121,7 @@ export const usePage = async ({
         // * https://github.com/puppeteer/puppeteer/issues/12637#issuecomment-2264825922
         "--disable-gpu",
       ],
+      protocolTimeout: 30 * 60 * 1000,
     });
 
     // Start recording, and only allow connections to likely API endpoints.


### PR DESCRIPTION
We're still running into timeout issues when running tests on CI as part of the deployment workflow. This dramatically increases the timeouts so we can see if puppeteer is freezing or just going slow.
