### PR TITLE
chore: fix typos in comments

### DIFF
--- a/src/cli/deploy.ts
+++ b/src/cli/deploy.ts
@@ -160,7 +160,7 @@ export const deployCommand = new Command()
       tarballFilename,
     );
 
-    // Atach the metadata to the form data.
+    // Attach the metadata to the form data.
     formData.append("meta", JSON.stringify(meta));
 
     // Attach the tags to the form data.

--- a/src/cli/lint.ts
+++ b/src/cli/lint.ts
@@ -221,7 +221,7 @@ export const lintCommand = new Command()
           );
           const libraryPathSupported: boolean =
             libraryPathSupportedTestCode === 0;
-          // Conditionally include library paths if supported by the Ciromspect version.
+          // Conditionally include library paths if supported by the Circomspect version.
           // It's important that this path logic is kept in sync with the Sindri backend.
           const libraryPathArgs: string[] = libraryPathSupported
             ? ["--library", ".", "--library", path.join(".", "node_modules")]


### PR DESCRIPTION
- deploy.ts: corrected "Atach" → "Attach".
- lint.ts: corrected "Ciromspect" → "Circomspect".