### PR TITLE
Extend nodejs version test matrix up to nodejs 25

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
   lint-and-test:
     strategy:
       matrix:
-        version: [18, 19, 20, 21, 22]
+        version: [18, 19, 20, 21, 22, 23, 24, 25]
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code


### PR DESCRIPTION
Node 25 was released today, this bumps up the versions in the test matrix to include the last several. Everything passes, so no other immediate changes were necessary.